### PR TITLE
feat: 가입 시 이메일 인증 추가

### DIFF
--- a/apigateway/src/main/java/com/dev_high/apigateway/config/WebFluxSecurityConfig.java
+++ b/apigateway/src/main/java/com/dev_high/apigateway/config/WebFluxSecurityConfig.java
@@ -27,8 +27,9 @@ public class WebFluxSecurityConfig {
 
 
   // 인증 필요없는 url
-  private final static String USER_JOIN_ANTPATTERNS = "api/v1/users/signup";
-  private final static String AUTH_ANTPATTERNS = "api/v1/auth/**";
+  private final static String USER_JOIN_ANTPATTERNS = "/api/v1/users/signup";
+  private final static String EMAIL_ANTPATTERNS = "/api/v1/auth/verify-email/**";
+  private final static String AUTH_ANTPATTERNS = "/api/v1/auth/**";
   private final static String[] AUCTION_ANTPATTERNS = {"/api/v1/auctions", "/api/v1/auctions/*",
       "/ws-auction/**"};
   private final static String[] PRODUCT_ANTPATTERNS = {"/api/v1/products", "/api/v1/products/*",
@@ -63,6 +64,7 @@ public class WebFluxSecurityConfig {
             .authorizeExchange(exchanges -> exchanges
                     .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()
                     .pathMatchers(AUTH_ANTPATTERNS).permitAll()
+                    .pathMatchers(EMAIL_ANTPATTERNS).permitAll()
                     .pathMatchers(HttpMethod.POST, USER_JOIN_ANTPATTERNS).permitAll()
                     .pathMatchers(HttpMethod.GET, AUCTION_ANTPATTERNS).permitAll()
                     .pathMatchers(HttpMethod.GET, PRODUCT_ANTPATTERNS).permitAll()

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -29,6 +29,13 @@ dependencies {
     // Database
     runtimeOnly 'org.postgresql:postgresql'
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/user/src/main/java/com/dev_high/user/auth/application/AuthService.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/AuthService.java
@@ -5,16 +5,26 @@ import com.dev_high.user.auth.application.dto.LoginCommand;
 import com.dev_high.user.auth.application.dto.LoginInfo;
 import com.dev_high.user.auth.application.dto.TokenCommand;
 import com.dev_high.user.auth.application.dto.TokenInfo;
+import com.dev_high.user.auth.domain.EmailVerificationCodeRepository;
 import com.dev_high.user.auth.exception.IncorrectPasswordException;
+import com.dev_high.user.auth.exception.MailSendFailedException;
 import com.dev_high.user.auth.jwt.JwtProvider;
+import com.dev_high.user.user.application.UserDomainService;
 import com.dev_high.user.user.domain.User;
 import com.dev_high.user.user.domain.UserRepository;
+import com.dev_high.user.user.domain.UserStatus;
 import com.dev_high.user.user.exception.UserNotFoundException;
 import io.jsonwebtoken.Claims;
+import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Optional;
+import java.util.Random;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +34,9 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
+    private final EmailVerificationCodeRepository emailVerificationCodeRepository;
+    private final EmailService mailService;
+    private final UserDomainService userDomainService;
 
     public ApiResponseDto<LoginInfo> login(LoginCommand command) {
         User user = userRepository.findByEmail(command.email()).orElseThrow(UserNotFoundException::new);
@@ -46,5 +59,45 @@ public class AuthService {
         String newAccess = jwtProvider.generateAccessToken(userId, claims.get("role", String.class));
         TokenInfo tokenInfo = new TokenInfo(newAccess);
         return ApiResponseDto.success(tokenInfo);
+    }
+
+    public void sendEmail(String email) {
+        String title = "More 이메일 인증 번호";
+        String authCode = this.createEmailVerificationCode();
+        log.info(authCode);
+        emailVerificationCodeRepository.save(email, authCode, 5);
+        try {
+            mailService.sendEmail(email, title, authCode);
+        } catch (MessagingException e) {
+            throw new MailSendFailedException();
+        }
+
+    }
+
+    @Transactional
+    public ApiResponseDto<Void> verifyEmail(String email, String code) {
+        Optional<String> emailVerificationCode = emailVerificationCodeRepository.findByEmail(email);
+        if (emailVerificationCode.isPresent()) {
+            String savedCode = emailVerificationCode.get();
+            if (savedCode.equals(code)) {
+                userDomainService.updateUserStatus(email, UserStatus.ACTIVE);
+                emailVerificationCodeRepository.deleteCode(email);
+            }
+        }
+        return ApiResponseDto.success(null);
+    }
+
+    private String createEmailVerificationCode() {
+        int length = 6;
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < length; i++) {
+                builder.append(random.nextInt(10));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException();
+        }
     }
 }

--- a/user/src/main/java/com/dev_high/user/auth/application/EmailService.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/EmailService.java
@@ -1,0 +1,36 @@
+package com.dev_high.user.auth.application;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender javaMailSender;
+    private final TemplateEngine templateEngine;
+
+    public void sendEmail(String to, String title, String code) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message);
+        helper.setTo(to);
+        helper.setSubject(title);
+        Context context = new Context();
+        context.setVariable("email", URLEncoder.encode(to, StandardCharsets.UTF_8));
+        context.setVariable("code", code);
+        String html = templateEngine.process("email-template", context);
+        helper.setText(html, true);
+        javaMailSender.send(message);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/config/RedisConfig.java
+++ b/user/src/main/java/com/dev_high/user/auth/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.dev_high.user.auth.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+}

--- a/user/src/main/java/com/dev_high/user/auth/domain/EmailVerificationCode.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/EmailVerificationCode.java
@@ -1,0 +1,29 @@
+package com.dev_high.user.auth.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@RedisHash("emailVerificationCode")
+public class EmailVerificationCode {
+
+    @Id
+    private String email;
+
+    private String code;
+
+    @TimeToLive
+    private Long ttl; // 초 단위 TTL
+
+    public EmailVerificationCode(String email, String code, Long ttl) {
+        this.email = email;
+        this.code = code;
+        this.ttl = ttl;
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/domain/EmailVerificationCodeRepository.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/EmailVerificationCodeRepository.java
@@ -1,0 +1,10 @@
+package com.dev_high.user.auth.domain;
+
+import java.util.Optional;
+
+public interface EmailVerificationCodeRepository {
+    void save(String email, String code, long ttlMinutes);
+    Optional<String> findByEmail(String email);
+    void deleteCode(String email);
+
+}

--- a/user/src/main/java/com/dev_high/user/auth/exception/MailSendFailedException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/MailSendFailedException.java
@@ -1,0 +1,14 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class MailSendFailedException extends CustomException {
+    public MailSendFailedException() {
+        super(HttpStatus.SERVICE_UNAVAILABLE, "가입 인증 코드 메일 전송에 실패했습니다.");
+    }
+
+    public MailSendFailedException(String errorCode, String message) {
+        super(HttpStatus.SERVICE_UNAVAILABLE, message, errorCode);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/infrastructure/EmailVerificationCodeCrudRepository.java
+++ b/user/src/main/java/com/dev_high/user/auth/infrastructure/EmailVerificationCodeCrudRepository.java
@@ -1,0 +1,7 @@
+package com.dev_high.user.auth.infrastructure;
+
+import com.dev_high.user.auth.domain.EmailVerificationCode;
+import org.springframework.data.repository.CrudRepository;
+
+public interface EmailVerificationCodeCrudRepository extends CrudRepository<EmailVerificationCode, String>{
+}

--- a/user/src/main/java/com/dev_high/user/auth/infrastructure/EmailVerificationCodeRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/auth/infrastructure/EmailVerificationCodeRepositoryAdapter.java
@@ -1,0 +1,33 @@
+package com.dev_high.user.auth.infrastructure;
+
+import com.dev_high.user.auth.domain.EmailVerificationCode;
+import com.dev_high.user.auth.domain.EmailVerificationCodeRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class EmailVerificationCodeRepositoryAdapter implements EmailVerificationCodeRepository {
+
+    private final EmailVerificationCodeCrudRepository emailVerificationCodeCrudRepository;
+
+    public EmailVerificationCodeRepositoryAdapter(EmailVerificationCodeCrudRepository emailVerificationCodeCrudRepository) {
+        this.emailVerificationCodeCrudRepository = emailVerificationCodeCrudRepository;
+    }
+
+    @Override
+    public void save(String email, String code, long ttlMinutes) {
+        emailVerificationCodeCrudRepository.save(new EmailVerificationCode(email, code, ttlMinutes * 60));
+    }
+
+    @Override
+    public Optional<String> findByEmail(String email) {
+        return emailVerificationCodeCrudRepository.findById(email)
+                .map(EmailVerificationCode::getCode);
+    }
+
+    @Override
+    public void deleteCode(String email) {
+        emailVerificationCodeCrudRepository.deleteById(email);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/presentation/AuthController.java
+++ b/user/src/main/java/com/dev_high/user/auth/presentation/AuthController.java
@@ -10,17 +10,21 @@ import com.dev_high.user.auth.application.dto.TokenInfo;
 import com.dev_high.user.auth.presentation.dto.LoginRequest;
 import com.dev_high.user.auth.presentation.dto.TokenRequest;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
 
 @RequestMapping("/api/v1/auth")
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class AuthController {
 
     private final AuthService authService;
+
+    @GetMapping("/verify-email/{email}/{code}")
+    public ApiResponseDto<Void> verifyEmail(@PathVariable("email") String email, @PathVariable("code") String code){
+        return authService.verifyEmail(email, code);
+    }
 
     @PostMapping("/login")
     public ApiResponseDto<LoginInfo> login(@RequestBody LoginRequest request){

--- a/user/src/main/java/com/dev_high/user/user/application/UserDomainService.java
+++ b/user/src/main/java/com/dev_high/user/user/application/UserDomainService.java
@@ -4,11 +4,14 @@ import com.dev_high.common.context.UserContext;
 import com.dev_high.user.user.domain.User;
 import com.dev_high.user.user.domain.UserRepository;
 import com.dev_high.user.user.domain.UserRole;
+import com.dev_high.user.user.domain.UserStatus;
 import com.dev_high.user.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserDomainService {
@@ -18,11 +21,18 @@ public class UserDomainService {
     public User getUser() {
         String userId = UserContext.get().userId();
         return userRepository.findById(userId)
-                .filter(user -> !"Y".equals(user.getDeletedYn())) // 삭제 여부 필터
+                .filter(user -> !"Y".equals(user.getDeletedYn()))
                 .orElseThrow(UserNotFoundException::new);
     }
 
     public void updateUserRole(User user, UserRole role) {
         user.updateRole(role);
+    }
+
+
+    @Transactional
+    public void updateUserStatus(String email, UserStatus status) {
+        User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
+        user.updateStatus(status);
     }
 }

--- a/user/src/main/java/com/dev_high/user/user/application/UserService.java
+++ b/user/src/main/java/com/dev_high/user/user/application/UserService.java
@@ -1,5 +1,6 @@
 package com.dev_high.user.user.application;
 
+import com.dev_high.user.auth.application.AuthService;
 import com.dev_high.user.seller.application.SellerService;
 import com.dev_high.user.user.application.dto.CreateUserCommand;
 import com.dev_high.user.user.application.dto.UpdatePasswordCommand;
@@ -11,21 +12,24 @@ import com.dev_high.user.user.domain.UserRole;
 import com.dev_high.user.user.exception.UserAlreadyExistsException;
 import lombok.RequiredArgsConstructor;
 import com.dev_high.common.dto.ApiResponseDto;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final SellerService sellerService;
     private final UserDomainService userDomainService;
+    private final AuthService authService;
 
     @Transactional
-    public ApiResponseDto<UserInfo> create(CreateUserCommand command) {
+    public ApiResponseDto<UserInfo> create(CreateUserCommand command){
         if(userRepository.existsByEmail(command.email())) {
          throw new UserAlreadyExistsException();
         }
@@ -41,6 +45,7 @@ public class UserService {
                 command.detail()
         );
         User saved = userRepository.save(user);
+        authService.sendEmail(saved.getEmail());
         return ApiResponseDto.success(UserInfo.from(saved));
     }
 

--- a/user/src/main/java/com/dev_high/user/user/domain/User.java
+++ b/user/src/main/java/com/dev_high/user/user/domain/User.java
@@ -125,4 +125,8 @@ public class User {
         this.userStatus = UserStatus.WITHDRAWN;
         this.deletedYn = "Y";
     }
+
+    public void updateStatus(UserStatus status) {
+        this.userStatus = status;
+    }
 }

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -19,6 +19,26 @@ spring:
           format_sql: true
           jdbc:
             time_zone: UTC
+  data:
+    redis:
+      host: localhost
+      port: 6379
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username:  ${more.mail.username}
+    password: ${more.mail.password}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    auth-code-expiration-millis: 1800000  # 30분
 
 jwt:
   secret: ${JWT_SECRET}

--- a/user/src/main/resources/templates/email-template.html
+++ b/user/src/main/resources/templates/email-template.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>이메일 인증</title>
+    <style>
+        body {
+            font-family: 'Arial', sans-serif;
+            background-color: #f4f4f4;
+            margin: 0;
+            padding: 20px 0;
+            text-align: center;
+        }
+
+        .email-container {
+            background-color: #ffffff;
+            padding: 30px;
+            border-radius: 8px;
+            box-shadow: 0px 4px 6px rgba(0,0,0,0.1);
+            display: inline-block;
+            text-align: left;
+        }
+
+        h1 {
+            color: #333333;
+            font-size: 24px;
+        }
+
+        p {
+            color: #555555;
+            font-size: 16px;
+            line-height: 1.5;
+        }
+
+        .code-wrapper {
+            text-align: center;
+            margin: 20px 0;
+        }
+
+        .code-button {
+            display: inline-block;
+            padding: 15px 25px;
+            font-size: 24px;
+            font-weight: bold;
+            color: #007BFF;
+            background-color: transparent;
+            border: 2px solid #007BFF;
+            border-radius: 6px;
+            text-decoration: none;
+            letter-spacing: 3px;
+            cursor: pointer;
+            transition: background-color 0.3s, color 0.3s;
+        }
+
+        .code-button:hover {
+            background-color: #007BFF;
+            color: #ffffff;
+            text-decoration: none;
+        }
+
+        .footer {
+            margin-top: 30px;
+            font-size: 12px;
+            color: #999999;
+            text-align: center;
+        }
+
+        @media screen and (max-width: 480px) {
+            .email-container {
+                padding: 20px;
+            }
+            h1 {
+                font-size: 20px;
+            }
+            p {
+                font-size: 14px;
+            }
+            .code-button {
+                font-size: 20px;
+                padding: 12px 20px;
+            }
+        }
+    </style>
+</head>
+<body>
+<div class="email-container">
+    <h1>More 이메일 인증 코드</h1>
+    <p>안녕하세요,</p>
+    <p>아래 인증 코드를 클릭하여 이메일 인증을 완료해주세요.</p>
+    <div class="code-wrapper">
+        <!-- Todo 이메일 인증 엔드 포인트 수정-->
+        <a th:href="@{'http://localhost:8000/api/v1/auth/verify-email/' + ${email} + '/' + ${code}}" class="code-button" th:text="${code}"></a>
+    </div>
+    <p>인증 코드는 <strong>5분간 유효</strong>합니다. 다른 사람과 공유하지 마세요.</p>
+    <div class="footer">
+        © 2025 More. All rights reserved.
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📎 연관된 Issue 번호
closed #45 

## 📄 작업 내용
이메일 인증 코드 생성 후 이메일을 아이디로 해당 코드를 redis 저장하고 유저에게 이메일 발송
이메일 인증 코드 확인 api 생성하여 이메일 내 버튼 클릭 시 바로 이메일 인증 가능
