### PR TITLE
feat: redis에서 refresh token 관리, LoginInfo 반환 데이터 추가

### DIFF
--- a/user/src/main/java/com/dev_high/user/auth/application/dto/LoginInfo.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/dto/LoginInfo.java
@@ -2,6 +2,8 @@ package com.dev_high.user.auth.application.dto;
 
 public record LoginInfo(
         String accessToken,
-        String refreshToken
+        String refreshToken,
+        String nickname,
+        String role
 ) {
 }

--- a/user/src/main/java/com/dev_high/user/auth/domain/RefreshToken.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/RefreshToken.java
@@ -1,0 +1,29 @@
+package com.dev_high.user.auth.domain;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@ToString
+@Getter
+@NoArgsConstructor
+@RedisHash("refreshToken")
+public class RefreshToken {
+
+    @Id
+    private String userId;
+
+    private String token;
+
+    @TimeToLive
+    private Long ttl; // 초 단위 TTL
+
+    public RefreshToken(String userId, String token, Long ttl) {
+        this.userId = userId;
+        this.token = token;
+        this.ttl = ttl;
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/domain/RefreshTokenRepository.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.dev_high.user.auth.domain;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(String userId, String refreshToken, long ttlMilliseconds);
+    Optional<RefreshToken> findByUserId(String userId);
+    void deleteByUserId(String userId);
+
+}

--- a/user/src/main/java/com/dev_high/user/auth/exception/RefreshTokenMismatchException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/RefreshTokenMismatchException.java
@@ -1,0 +1,10 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenMismatchException extends CustomException {
+    public RefreshTokenMismatchException() {
+        super(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다.");
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/exception/RefreshTokenNotFoundException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/RefreshTokenNotFoundException.java
@@ -1,0 +1,10 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenNotFoundException extends CustomException {
+    public RefreshTokenNotFoundException() {
+        super(HttpStatus.UNAUTHORIZED, "해당 Refresh Token이 존재하지 않습니다.");
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenCrudRepository.java
+++ b/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenCrudRepository.java
@@ -1,0 +1,7 @@
+package com.dev_high.user.auth.infrastructure;
+
+import com.dev_high.user.auth.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+
+public interface RefreshTokenCrudRepository extends CrudRepository<RefreshToken, String>{
+}

--- a/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenRepositoryAdapter.java
@@ -1,0 +1,32 @@
+package com.dev_high.user.auth.infrastructure;
+
+import com.dev_high.user.auth.domain.RefreshToken;
+import com.dev_high.user.auth.domain.RefreshTokenRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
+
+    private final RefreshTokenCrudRepository refreshTokenCrudRepository;
+
+    public RefreshTokenRepositoryAdapter(RefreshTokenCrudRepository refreshTokenCrudRepository) {
+        this.refreshTokenCrudRepository = refreshTokenCrudRepository;
+    }
+
+    @Override
+    public void save(String userId, String refreshToken, long ttlMilliseconds) {
+        refreshTokenCrudRepository.save(new RefreshToken(userId, refreshToken, ttlMilliseconds/1000));
+    }
+
+    @Override
+    public Optional<RefreshToken> findByUserId(String userId) {
+        return refreshTokenCrudRepository.findById(userId);
+    }
+
+    @Override
+    public void deleteByUserId(String userId) {
+        refreshTokenCrudRepository.deleteById(userId);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/presentation/AuthController.java
+++ b/user/src/main/java/com/dev_high/user/auth/presentation/AuthController.java
@@ -46,5 +46,4 @@ public class AuthController {
         );
         return authService.refreshToken(command);
     }
-
 }

--- a/user/src/main/java/com/dev_high/user/user/application/UserService.java
+++ b/user/src/main/java/com/dev_high/user/user/application/UserService.java
@@ -1,5 +1,7 @@
 package com.dev_high.user.user.application;
 
+import com.dev_high.common.context.UserContext;
+import com.dev_high.user.auth.application.AuthService;
 import com.dev_high.user.seller.application.SellerService;
 import com.dev_high.user.seller.domain.SellerStatus;
 import com.dev_high.user.user.application.dto.CreateUserCommand;
@@ -25,6 +27,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final SellerService sellerService;
+    private final AuthService authService;
     private final UserDomainService userDomainService;
 
     @Transactional
@@ -75,6 +78,14 @@ public class UserService {
             sellerService.deleteSeller(SellerStatus.WITHDRAWN);
         }
         user.deleteUser();
+        return ApiResponseDto.success(null);
+    }
+
+
+    @Transactional
+    public ApiResponseDto<Void> logout() {
+        String userId = UserContext.get().userId();
+        authService.logout(userId);
         return ApiResponseDto.success(null);
     }
 }

--- a/user/src/main/java/com/dev_high/user/user/presentation/UserController.java
+++ b/user/src/main/java/com/dev_high/user/user/presentation/UserController.java
@@ -43,4 +43,9 @@ public class UserController {
         return userService.delete();
     }
 
+    @PostMapping("/logout")
+    public ApiResponseDto<Void> logout(){
+        return userService.logout();
+    }
+
 }

--- a/user/src/main/resources/application.yml
+++ b/user/src/main/resources/application.yml
@@ -38,7 +38,6 @@ spring:
           connectiontimeout: 5000
           timeout: 5000
           writetimeout: 5000
-    auth-code-expiration-millis: 1800000  # 30분
 
 jwt:
   secret: ${JWT_SECRET}


### PR DESCRIPTION
## 📎 연관된 Issue 번호
closed #52

## 📄 작업 내용
- refresh 발급 후 redis에 저장
- redis를 활용한 로그아웃 로직 구현
- loginInfo에 닉네임 role 추가