### PR TITLE
fix: deposit 히스토리 엔티티 id 컬럼 수정

### DIFF
--- a/deposit/src/main/java/com/dev_high/deposit/domain/DepositHistory.java
+++ b/deposit/src/main/java/com/dev_high/deposit/domain/DepositHistory.java
@@ -19,6 +19,7 @@ public class DepositHistory {
     @Schema(description = "예치금 이력 ID")
     @Id
     @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /*

--- a/deposit/src/main/java/com/dev_high/deposit/domain/DepositPaymentFailureHistory.java
+++ b/deposit/src/main/java/com/dev_high/deposit/domain/DepositPaymentFailureHistory.java
@@ -19,6 +19,7 @@ public class DepositPaymentFailureHistory {
     @Schema(description = "예치금 결제 실패 이력 ID")
     @Id
     @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     /*


### PR DESCRIPTION
## 📎 연관된 Issue 번호
#86

## 📄 작업 내용
deposit_history 엔티티 id 컬럼 @GeneratedValue 추가
deposit_payment_failure_history 엔티티 id 컬럼 @GeneratedValue 추가