### PR TITLE
fix : 예치금 내역, 알림 내역 조회시 생성일시 내림차순 정렬 적용

### DIFF
--- a/deposit/src/main/java/com/dev_high/deposit/infrastructure/DepositHistoryJpaRepository.java
+++ b/deposit/src/main/java/com/dev_high/deposit/infrastructure/DepositHistoryJpaRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DepositHistoryJpaRepository extends JpaRepository<DepositHistory, Long> {
-    Page<DepositHistory> findByUserId(String userId, Pageable pageable);
+    Page<DepositHistory> findByUserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
 }

--- a/deposit/src/main/java/com/dev_high/deposit/infrastructure/DepositHistoryRepositoryAdapter.java
+++ b/deposit/src/main/java/com/dev_high/deposit/infrastructure/DepositHistoryRepositoryAdapter.java
@@ -19,6 +19,6 @@ public class DepositHistoryRepositoryAdapter implements DepositHistoryRepository
 
     @Override
     public Page<DepositHistory> findByUserId(String userId, Pageable pageable) {
-        return repository.findByUserId(userId, pageable);
+        return repository.findByUserIdOrderByCreatedAtDesc(userId, pageable);
     }
 }

--- a/notification/src/main/java/com/dev_high/notification/infrastructure/NotificationJpaRepository.java
+++ b/notification/src/main/java/com/dev_high/notification/infrastructure/NotificationJpaRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, String> {
-    Page<NotificationInfo> findAllByUserId(String userId, Pageable pageable);
+    Page<NotificationInfo> findAllByUserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
 
     long countByUserIdAndReadYn(String userId, Boolean readYn);
 }

--- a/notification/src/main/java/com/dev_high/notification/infrastructure/NotificationRepositoryAdapter.java
+++ b/notification/src/main/java/com/dev_high/notification/infrastructure/NotificationRepositoryAdapter.java
@@ -22,7 +22,7 @@ public class NotificationRepositoryAdapter implements NotificationRepository {
 
     @Override
     public Page<NotificationInfo> findAllByUserId(String userId, Pageable pageable) {
-        return repository.findAllByUserId(userId, pageable);
+        return repository.findAllByUserIdOrderByCreatedAtDesc(userId, pageable);
     }
 
     @Override


### PR DESCRIPTION
## 📎 연관된 Issue 번호
#112 

## 📄 작업 내용
예치금 내역, 알림 내역 조회시 생성일시 내림차순 정렬 적용