### PR TITLE
feat: consumer event 공통설정

### DIFF
--- a/auction/src/main/java/com/dev_high/auction/AuctionApplication.java
+++ b/auction/src/main/java/com/dev_high/auction/AuctionApplication.java
@@ -5,10 +5,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 
-@EntityScan(basePackages = {
-    "com.dev_high.auction.domain",
-    "com.dev_high.product.domain" // Product 엔티티 포함
-})
 @SpringBootApplication(scanBasePackages = {"com.dev_high.auction", "com.dev_high.common"})
 @EnableDiscoveryClient
 public class AuctionApplication {

--- a/common/src/main/java/com/dev_high/common/config/CommonConfig.java
+++ b/common/src/main/java/com/dev_high/common/config/CommonConfig.java
@@ -1,0 +1,14 @@
+package com.dev_high.common.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan("com.dev_high")
+@EnableJpaRepositories("com.dev_high")
+@ComponentScan("com.dev_high")
+public class CommonConfig {
+
+}

--- a/common/src/main/java/com/dev_high/common/kafka/KafkaEventEnvelope.java
+++ b/common/src/main/java/com/dev_high/common/kafka/KafkaEventEnvelope.java
@@ -1,6 +1,8 @@
 package com.dev_high.common.kafka;
 
-public record KafkaEventEnvelope<T>(
+import java.util.UUID;
+
+public record KafkaEventEnvelope<T>(UUID eventId,
     String module,       // 이벤트 발행 모듈명
     String eventType,    // 이벤트 클래스명
     long timestamp,      // 발행 시각
@@ -11,7 +13,7 @@ public record KafkaEventEnvelope<T>(
    * payload와 module명을 받아서 envelope 생성
    */
   public static <T> KafkaEventEnvelope<T> wrap(String module, T payload) {
-    return new KafkaEventEnvelope<>(
+    return new KafkaEventEnvelope<>(UUID.randomUUID(),
         module,
         payload.getClass().getSimpleName(),
         System.currentTimeMillis(),

--- a/common/src/main/java/com/dev_high/common/kafka/KafkaIdempotencySupport.java
+++ b/common/src/main/java/com/dev_high/common/kafka/KafkaIdempotencySupport.java
@@ -1,0 +1,25 @@
+package com.dev_high.common.kafka;
+
+import com.dev_high.common.kafka.domain.ConsumedEvent;
+import com.dev_high.common.kafka.domain.ConsumedEventJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaIdempotencySupport {
+
+    private final ConsumedEventJpaRepository consumedEventJpaRepository;
+
+    public boolean alreadyConsumed(UUID eventId, String moduleName) {
+        try {
+            consumedEventJpaRepository.save(new ConsumedEvent(eventId, moduleName));
+            return false;
+        } catch (DataIntegrityViolationException e) {
+            return true;
+        }
+    }
+}

--- a/common/src/main/java/com/dev_high/common/kafka/KafkaListenerLoggingAspect.java
+++ b/common/src/main/java/com/dev_high/common/kafka/KafkaListenerLoggingAspect.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class KafkaListenerLoggingAspect {
 
   private final ObjectMapper objectMapper;
+  private  final KafkaIdempotencySupport kafkaIdempotencySupport;
   private static final Logger log = LoggerFactory.getLogger("KAFKA_LOG");
 
   @Value("${spring.application.name:unknown-module}")
@@ -51,6 +52,11 @@ public class KafkaListenerLoggingAspect {
 
       return joinPoint.proceed();
     }
+    // uuid , module name으로 유니크체크
+    if(kafkaIdempotencySupport.alreadyConsumed(envelope.eventId(),envelope.module())){
+
+          return null;
+      }
 
     // latency
     long receiveTimestamp = System.currentTimeMillis();

--- a/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEvent.java
+++ b/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEvent.java
@@ -1,0 +1,31 @@
+package com.dev_high.common.kafka.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "consumed_event",schema = "public")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConsumedEvent {
+
+    @EmbeddedId
+    private ConsumedEventId id;
+
+    @Column(name = "consumed_at", nullable = false)
+    private OffsetDateTime consumedAt;
+
+
+    public ConsumedEvent(UUID eventId, String moduleName) {
+        this.id = new ConsumedEventId(eventId, moduleName);
+        this.consumedAt = OffsetDateTime.now();
+    }
+}

--- a/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEventId.java
+++ b/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEventId.java
@@ -1,0 +1,19 @@
+package com.dev_high.common.kafka.domain;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class ConsumedEventId implements Serializable {
+
+    @Column(name = "id", nullable = false, length = 36)
+    private UUID id;
+
+    @Column(name = "module_name", nullable = false, length = 50)
+    private String moduleName;
+}

--- a/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEventJpaRepository.java
+++ b/common/src/main/java/com/dev_high/common/kafka/domain/ConsumedEventJpaRepository.java
@@ -1,0 +1,8 @@
+package com.dev_high.common.kafka.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ConsumedEventJpaRepository extends JpaRepository<ConsumedEvent, ConsumedEventId> {
+}


### PR DESCRIPTION
## 📄 배경
이 PR이 필요하게 된 배경을 설명해 주세요.

기존 Kafka 이벤트 처리 과정에서는 동일한 이벤트가 여러 번 소비되더라도 중복 처리 방지가 없었음.

---

## 🎯 의도
이 PR을 통해 달성하고자 하는 목표를 작성해 주세요.

이미 처리된 이벤트의 재실행을 방지하기 위함

- 이벤트 발행 시 고유 eventId를 생성
- 이벤트 소비 직전, 기존 AOP를 이용하여 중복 여부 검증
- 중복 여부 통과시 ConsumedEvent 테이블에 기록
- 각 서비스의 이벤트리스너에 트랜잭션 처리가 필요 

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [x] Envelop 공통 dto에 uuid 추가
- [x] ConsumedEvent entity ,repository 생성
- [x] AOP 내부에서 소비 내역 insert
- [x] db에 테이블 추가

---

## 📎 연관된 Issue 번호
<!-- closed #번호 -->
Close #181 
---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
