### PR TITLE
fix: 상품에서 권한검증코드 삭제 및 상품다건조회byIds 추가

### DIFF
--- a/product/src/main/java/com/dev_high/product/application/ProductService.java
+++ b/product/src/main/java/com/dev_high/product/application/ProductService.java
@@ -112,6 +112,14 @@ public class ProductService {
         return products.stream().map(ProductInfo::from).toList();
     }
 
+
+    @Transactional(readOnly = true)
+    public List<ProductInfo> getProductsByProductIds(List<String> productIds) {
+        List<Product> products;
+        products = productRepository.findByProductIds(productIds);
+        return products.stream().map(ProductInfo::from).toList();
+    }
+
     @Transactional(readOnly = true)
     public List<ProductInfo> getProductsBySeller(String sellerId) {
         return productRepository.findBySellerId(sellerId).stream()

--- a/product/src/main/java/com/dev_high/product/application/ProductService.java
+++ b/product/src/main/java/com/dev_high/product/application/ProductService.java
@@ -38,7 +38,7 @@ public class ProductService {
     // 상품생성 트랜잭션
     @Transactional
     public Product saveProduct(ProductCommand command) {
-        UserInfo userInfo = ensureSellerRole();
+        UserInfo userInfo = UserContext.get();
         String sellerId = userInfo.userId();
 
         Product product = Product.create(
@@ -76,7 +76,7 @@ public class ProductService {
     public ProductInfo updateProduct(String productId, ProductUpdateCommand command) {
 
         //셀러 및 상품생성자 일치 검증
-        UserInfo userInfo = ensureSellerRole();
+        UserInfo userInfo = UserContext.get();
         Product product = productRepository.findById(productId)
                 .orElseThrow(ProductNotFoundException::new);
         if (userInfo.userId() == null || !userInfo.userId().equals(product.getSellerId())) {
@@ -146,19 +146,6 @@ public class ProductService {
     /**
 
      **/
-
-    //판매자 검증
-    private UserInfo ensureSellerRole() {
-        UserInfo userInfo = UserContext.get();
-        if (userInfo == null || userInfo.userId() == null || !"SELLER".equalsIgnoreCase(userInfo.role())) {
-
-            if (!"ADMIN".equals(userInfo.role())) {
-                throw new ProductUnauthorizedException("판매자만 상품을 등록/수정할 수 있습니다.", "PRODUCT_SELLER_ONLY");
-            }
-
-        }
-        return userInfo;
-    }
 
     public List<WishlistProductResponse> getProductInfos(List<String> productIds) {
         if (productIds == null || productIds.isEmpty()) {

--- a/product/src/main/java/com/dev_high/product/domain/ProductRepository.java
+++ b/product/src/main/java/com/dev_high/product/domain/ProductRepository.java
@@ -22,4 +22,5 @@ public interface ProductRepository {
 
     List<Product> findBySellerId(String sellerId);
 
+    List<Product> findByProductIds(List<String> productIds);
 }

--- a/product/src/main/java/com/dev_high/product/infraStructure/ProductRepositoryAdapter.java
+++ b/product/src/main/java/com/dev_high/product/infraStructure/ProductRepositoryAdapter.java
@@ -37,6 +37,11 @@ public class ProductRepositoryAdapter implements ProductRepository {
     }
 
     @Override
+    public List<Product> findByProductIds(List<String> productIds) {
+        return productJpaRepository.findAllById(productIds);
+    }
+
+    @Override
     public void saveAll(List<Product> products) {
         productJpaRepository.saveAll(products);
     }

--- a/product/src/main/java/com/dev_high/product/presentation/ProductController.java
+++ b/product/src/main/java/com/dev_high/product/presentation/ProductController.java
@@ -51,6 +51,13 @@ public class ProductController {
         return ApiResponseDto.success(productService.getProduct(productId));
     }
 
+
+    @Operation(summary = "상품 다건 조회", description = "카테고리 정보를 포함한 상품 여러 건을 조회합니다.")
+    @GetMapping("/{productId}/many")
+    public ApiResponseDto<List<ProductInfo>> getProduct(@Parameter(description = "상품 ID", required = true) @PathVariable List<String> productId) {
+        return ApiResponseDto.success(productService.getProductsByProductIds(productId));
+    }
+
     @Operation(summary = "상품 수정", description = "판매자 본인이고 READY 상태일 때 상품 정보를 수정합니다.")
     @PutMapping("/{productId}")
     public ApiResponseDto<ProductInfo> updateProduct(@Parameter(description = "상품 ID", required = true) @PathVariable String productId,


### PR DESCRIPTION
## 📄 배경

apigateway에서 권한까지 검증함에 따라 product에서는 권한 검증의 필요성이 낮아짐
UserInfo에서 role 필드가 없어짐-> product 빌드 실패

---

## 🎯 의도

role 검증 코드 삭제를 통한 product 빌드 실패 해결
변경된 권한 검증 방식에 대응

---

## ✅ 작업 내용

- [x] 상품 생성, 수정, 삭제 시 seller 권한 검증 코드 삭제
- [x] List<String> productIds를 파라미터로 하는 상품다건조회 엔드포인트 및 서비스 코드 작성
---

## 📎 연관된 Issue 번호
<!-- closed #194  -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.

