### PR TITLE
fix: 게이트웨이 인가처리 조건 제거

### DIFF
--- a/apigateway/src/main/java/com/dev_high/apigateway/config/WebFluxSecurityConfig.java
+++ b/apigateway/src/main/java/com/dev_high/apigateway/config/WebFluxSecurityConfig.java
@@ -4,14 +4,14 @@ import com.dev_high.apigateway.security.AuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.authorization.ReactiveAuthorizationManager;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.web.server.SecurityWebFilterChain;
-import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.web.server.authorization.AuthorizationContext;
 import org.springframework.web.cors.CorsConfiguration;
+
 import java.util.List;
 
 @Configuration
@@ -38,10 +38,6 @@ public class WebFluxSecurityConfig {
                 .headers(headers -> headers.frameOptions(
                         ServerHttpSecurity.HeaderSpec.FrameOptionsSpec::disable))
                 .cors(cors -> cors.configurationSource(request -> {
-                    String path = request.getRequest().getURI().getPath();
-                    if (path.startsWith("/ws-auction")) {
-                        return null;
-                    }
                     CorsConfiguration config = new CorsConfiguration();
                     config.setAllowedOriginPatterns(List.of(
                             "http://localhost:[*]",
@@ -56,12 +52,6 @@ public class WebFluxSecurityConfig {
                     return config;
                 }))
                 .addFilterAt(authenticationFilter, SecurityWebFiltersOrder.AUTHENTICATION)
-                .exceptionHandling(e -> e
-                        .accessDeniedHandler((exchange, ex) -> {
-                            exchange.getResponse().setStatusCode(HttpStatus.FORBIDDEN);
-                            return exchange.getResponse().setComplete();
-                        })
-                )
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .pathMatchers(PERMITALL_ANTPATTERNS).permitAll()

--- a/apigateway/src/main/java/com/dev_high/apigateway/security/AuthorizationManager.java
+++ b/apigateway/src/main/java/com/dev_high/apigateway/security/AuthorizationManager.java
@@ -57,11 +57,6 @@ public class AuthorizationManager implements ReactiveAuthorizationManager<Author
     private boolean isAllowed(Set<String> allowedRoles, Set<String> userRoles) {
         if (allowedRoles == null || allowedRoles.isEmpty()) return false;
 
-        // SELLER가 아닌 USER만 허용
-        if (allowedRoles.size() == 1 && allowedRoles.contains("USER")) {
-            return userRoles.size() == 1 && userRoles.contains("USER");
-        }
-
         for (String role : allowedRoles) {
             if (role != null && userRoles.contains(role)) {
                 return true;

--- a/auction/src/main/java/com/dev_high/auction/config/WebsoketConfig.java
+++ b/auction/src/main/java/com/dev_high/auction/config/WebsoketConfig.java
@@ -14,7 +14,7 @@ public class WebsoketConfig implements WebSocketMessageBrokerConfigurer {
   public void registerStompEndpoints(StompEndpointRegistry registry) {
     registry.addEndpoint("/ws-auction")       // 클라이언트 연결 엔드포인트
         .setAllowedOriginPatterns("*")    // CORS 허용
-        .withSockJS();                     // SockJS fallback
+        .withSockJS().setSuppressCors(true);                     // SockJS fallback
   }
 
   @Override


### PR DESCRIPTION
## 📄 배경
이 PR이 필요하게 된 배경을 설명해 주세요.

- endpoint rule 등록시 USER,SELLER 중복되게 저장됨

---

## 🎯 의도
이 PR을 통해 달성하고자 하는 목표를 작성해 주세요.

- 기존의 USER 만 접근 가능한 endpoint(셀러 등록)은 따로 예외처리
- 기존의 게이트웨이 인가처리에서 조건제거

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [X] 허용 가능한 role이 하나만 있을때  조건제거
- [X] WebFluxSecurity 정리 
- [X] 경매서비스에 Websocket  cors Header 중복 방지 

---

## 📎 연관된 Issue 번호
<!-- closed #번호 -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
