### PR TITLE
feat: 경매 시작 알림 연동을 Kafka로 변경

### DIFF
--- a/user/src/main/java/com/dev_high/user/wishlist/application/WishlistEventListener.java
+++ b/user/src/main/java/com/dev_high/user/wishlist/application/WishlistEventListener.java
@@ -1,0 +1,50 @@
+package com.dev_high.user.wishlist.application;
+
+import com.dev_high.common.kafka.KafkaEventEnvelope;
+import com.dev_high.common.kafka.KafkaEventPublisher;
+import com.dev_high.common.kafka.event.NotificationRequestEvent;
+import com.dev_high.common.kafka.event.auction.AuctionStartEvent;
+import com.dev_high.common.kafka.topics.KafkaTopics;
+import com.dev_high.common.type.NotificationCategory;
+import com.dev_high.common.util.JsonUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WishlistEventListener {
+
+    private final KafkaEventPublisher eventPublisher;
+    private final WishlistService wishlistService;
+
+    @KafkaListener(topics = KafkaTopics.AUCTION_START_EVENT)
+    public void onAuctionStart(KafkaEventEnvelope<?> envelope, ConsumerRecord<?, ?> record) {
+        try {
+            AuctionStartEvent event =
+                    JsonUtil.fromPayload(envelope.payload(), AuctionStartEvent.class);
+
+            List<String> userIds = wishlistService.publishNotificationRequestOnAuctionStart(event);
+
+            NotificationRequestEvent notificationRequestEvent = new NotificationRequestEvent(
+                    userIds,
+                    "찜한 상품의 경매가 시작되었습니다.",
+                    "/auctions/" + event.auctionId(),
+                    NotificationCategory.Type.WISHLIST
+            );
+
+            if(!userIds.isEmpty()) {
+                eventPublisher.publish(KafkaTopics.NOTIFICATION_REQUEST, notificationRequestEvent);
+            }
+
+        } catch (Exception e) {
+            log.error("찜한 상품 알림 처리 실패 재시도: {}", e.getMessage());
+            throw e;
+        }
+    }
+
+}

--- a/user/src/main/java/com/dev_high/user/wishlist/presentation/WishlistController.java
+++ b/user/src/main/java/com/dev_high/user/wishlist/presentation/WishlistController.java
@@ -9,8 +9,6 @@ import com.dev_high.user.wishlist.presentation.dto.WishlistRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping("/api/v1/users/wishlist")
 @RequiredArgsConstructor
@@ -31,10 +29,5 @@ public class WishlistController {
     @DeleteMapping
     public ApiResponseDto<Void> delete(@RequestBody WishlistRequest request) {
         return wishlistService.delete(request.toCommand());
-    }
-
-    @GetMapping("/{productId}")
-    public ApiResponseDto<List<String>> getUserIdsByProductId(@PathVariable("productId") String productId) {
-        return wishlistService.getUserIdsByProductId(productId);
     }
 }


### PR DESCRIPTION
## 📄 배경
이 PR이 필요하게 된 배경을 설명해 주세요.

[전]

- 경매 시작 시, 해당 상품을 찜한 유저 리스트 조회를 위해 경매 서비스 → 유저(위시리스트) 서비스로 RestTemplate 동기 호출

- 찜 유저 리스트 조회 후, 경매 서비스 → 알림 서비스로 Kafka 이벤트 발행(알림 생성 요청)

[후]

- 경매 시작 시, 경매 서비스 → 유저 서비스로 Kafka 이벤트 발행(경매 시작)

- 찜 유저 리스트 조회 후, 유저 서비스 → 알림 서비스로 Kafka 이벤트 발행(알림 생성 요청)

---

## 🎯 의도
이 PR을 통해 달성하고자 하는 목표를 작성해 주세요.

- 유저 서비스 내 wishlist에서 경매 시작 알림 이벤트 소비 후
- 찜 유저 리스트 조회 후 알림 서비스로 알림 생성 요청 이벤트 발행

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [x] wishlist 내 kafa event listener 생성(경매 시작)
- [x] wishlist event publisher 추가(알림 생성 요청)

---

## 📎 연관된 Issue 번호
closed #214 

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
