### PR TITLE
feat: 만료일자 이내 알림 내역 조회 추가,

### DIFF
--- a/user/src/main/java/com/dev_high/user/notification/domain/repository/NotificationRepository.java
+++ b/user/src/main/java/com/dev_high/user/notification/domain/repository/NotificationRepository.java
@@ -4,6 +4,7 @@ import com.dev_high.user.notification.domain.entity.Notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 public interface NotificationRepository {
@@ -11,7 +12,11 @@ public interface NotificationRepository {
 
     Page<Notification> findAllByUserId(String userId, Pageable pageable);
 
+    Page<Notification> findAllByUserIdAndExpiredAt(String userId, OffsetDateTime now, Pageable pageable);
+
     Long countUnreadByUserId(String userId);
+
+    int markAllUnreadActiveAsRead(String userId, OffsetDateTime now);
 
     Optional<Notification> findById(String notificationId);
 }

--- a/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationJpaRepository.java
+++ b/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationJpaRepository.java
@@ -1,12 +1,28 @@
 package com.dev_high.user.notification.infrastructure;
 
 import com.dev_high.user.notification.domain.entity.Notification;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.OffsetDateTime;
 
 public interface NotificationJpaRepository extends JpaRepository<Notification, String> {
     Page<Notification> findAllByUserIdOrderByCreatedAtDesc(String userId, Pageable pageable);
 
+    Page<Notification> findAllByUserIdAndExpiredAtAfterOrderByCreatedAtDesc(String userId, OffsetDateTime now, Pageable pageable);
+
     Long countByUserIdAndReadYn(String userId, Boolean readYn);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = "UPDATE \"user\".notification" +
+            "SET read_yn = 'Y', updated_at = :now, updated_by = :userId" +
+            "WHERE user_id = :userId AND read_yn = 'N' AND expired_at > :now", nativeQuery = true)
+    int markAllUnreadActiveAsRead(
+            @Param("userId") String userId,
+            @Param("now") OffsetDateTime now
+    );
 }

--- a/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationRepositoryAdapter.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 
 @Repository
@@ -25,8 +26,18 @@ public class NotificationRepositoryAdapter implements NotificationRepository {
     }
 
     @Override
+    public Page<Notification> findAllByUserIdAndExpiredAt(String userId, OffsetDateTime now, Pageable pageable) {
+        return repository.findAllByUserIdAndExpiredAtAfterOrderByCreatedAtDesc(userId, now, pageable);
+    }
+
+    @Override
     public Long countUnreadByUserId(String userId) {
         return repository.countByUserIdAndReadYn(userId, false);
+    }
+
+    @Override
+    public int markAllUnreadActiveAsRead(String userId, OffsetDateTime now) {
+        return repository.markAllUnreadActiveAsRead(userId, now);
     }
 
     @Override

--- a/user/src/main/java/com/dev_high/user/notification/presentation/NotificationController.java
+++ b/user/src/main/java/com/dev_high/user/notification/presentation/NotificationController.java
@@ -17,9 +17,17 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @Operation(summary = "알림 내역 조회", description = "로그인한 사용자 ID별 알림을 조회")
-    @GetMapping
+    @GetMapping("/me")
     public ApiResponseDto<Page<NotificationResponse.Detail>> getAllNotifications(Pageable pageable) {
         Page<NotificationDto.Info> infos = notificationService.getAllNotifications(pageable);
+        Page<NotificationResponse.Detail> response = infos.map(NotificationResponse.Detail::from);
+        return ApiResponseDto.success(response);
+    }
+
+    @Operation(summary = "만료일자 이내 알림 내역 조회", description = "로그인한 사용자 ID별 만료일자가 지나지 않은 알림을 조회")
+    @GetMapping
+    public ApiResponseDto<Page<NotificationResponse.Detail>> getActiveNotifications(Pageable pageable) {
+        Page<NotificationDto.Info> infos = notificationService.getActiveNotifications(pageable);
         Page<NotificationResponse.Detail> response = infos.map(NotificationResponse.Detail::from);
         return ApiResponseDto.success(response);
     }
@@ -30,6 +38,12 @@ public class NotificationController {
         NotificationDto.Count count = notificationService.getUnreadNotificationCount();
         NotificationResponse.Count response = NotificationResponse.Count.from(count);
         return ApiResponseDto.success(response);
+    }
+
+    @Operation(summary = "만료일자 이내 미확인 알림 일괄 읽음 처리", description = "로그인한 사용자 ID별 만료일자가 지나지 않은 미확인 알림을 일괄 읽음 처리")
+    @PutMapping("/read-all")
+    public ApiResponseDto<Void> readAllNotifications() {
+        return notificationService.markAllAsRead();
     }
 
     @Operation(summary = "알림 상세 조회", description = "알림 ID에 해당하는 알림 정보를 조회")


### PR DESCRIPTION
## 📄 배경
기존 알림은 클릭을 해야 읽음 처리가 되는데, 일괄 처리가 없어서 불편했다.

---

## 🎯 의도
일괄 처리를 추가하여, 프론트에서 컨트롤 할 수 있도록 한다.

---

## ✅ 작업 내용
- [x] 읽지 않은 알림 일괄 처리 추가
- [x] 만료일자 이내 알림 내역 조회 추가

---

## 📎 연관된 Issue 번호


---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
