### PR TITLE
fix: 읽지 않은 알림 갯수 카운트시 만료일자 조건 추가

### DIFF
--- a/user/src/main/java/com/dev_high/user/notification/application/NotificationService.java
+++ b/user/src/main/java/com/dev_high/user/notification/application/NotificationService.java
@@ -46,7 +46,9 @@ public class NotificationService {
     @Transactional(readOnly = true)
     public NotificationDto.Count getUnreadNotificationCount() {
         String userId = UserContext.get().userId();
-        return NotificationDto.Count.from(notificationRepository.countUnreadByUserId(userId));
+        OffsetDateTime now = OffsetDateTime.now();
+
+        return NotificationDto.Count.from(notificationRepository.countUnreadByUserId(userId, now));
     }
 
     @Transactional

--- a/user/src/main/java/com/dev_high/user/notification/domain/repository/NotificationRepository.java
+++ b/user/src/main/java/com/dev_high/user/notification/domain/repository/NotificationRepository.java
@@ -14,7 +14,7 @@ public interface NotificationRepository {
 
     Page<Notification> findAllByUserIdAndExpiredAt(String userId, OffsetDateTime now, Pageable pageable);
 
-    Long countUnreadByUserId(String userId);
+    Long countUnreadByUserId(String userId, OffsetDateTime now);
 
     int markAllUnreadActiveAsRead(String userId, OffsetDateTime now);
 

--- a/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationJpaRepository.java
+++ b/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationJpaRepository.java
@@ -15,7 +15,7 @@ public interface NotificationJpaRepository extends JpaRepository<Notification, S
 
     Page<Notification> findAllByUserIdAndExpiredAtAfterOrderByCreatedAtDesc(String userId, OffsetDateTime now, Pageable pageable);
 
-    Long countByUserIdAndReadYn(String userId, Boolean readYn);
+    Long countByUserIdAndReadYnAndExpiredAtAfter(String userId, Boolean readYn, OffsetDateTime now);
 
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(value = "UPDATE \"user\".notification" +

--- a/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/notification/infrastructure/NotificationRepositoryAdapter.java
@@ -31,8 +31,8 @@ public class NotificationRepositoryAdapter implements NotificationRepository {
     }
 
     @Override
-    public Long countUnreadByUserId(String userId) {
-        return repository.countByUserIdAndReadYn(userId, false);
+    public Long countUnreadByUserId(String userId, OffsetDateTime now) {
+        return repository.countByUserIdAndReadYnAndExpiredAtAfter(userId, false, now);
     }
 
     @Override

--- a/user/src/main/java/com/dev_high/user/notification/presentation/NotificationController.java
+++ b/user/src/main/java/com/dev_high/user/notification/presentation/NotificationController.java
@@ -32,7 +32,7 @@ public class NotificationController {
         return ApiResponseDto.success(response);
     }
 
-    @Operation(summary = "읽지 않은 알림 갯수 카운트", description = "로그인한 사용자 ID별 읽지않은 알림 갯수 카운트를 조회")
+    @Operation(summary = "읽지 않은 알림 갯수 카운트", description = "로그인한 사용자 ID별 만료일자가 지나지 않은 읽지 않은 알림 갯수 카운트를 조회")
     @GetMapping("/unread/count")
     public ApiResponseDto<NotificationResponse.Count> getUnreadNotificationCount() {
         NotificationDto.Count count = notificationService.getUnreadNotificationCount();


### PR DESCRIPTION
## 📄 배경
읽지 않은 알림 갯수 카운트시 만료일자 조건이 없어서 실제 노출되는 리스트와 차이가 발생
---

## 🎯 의도
읽지 않은 알림 갯수 카운트시 만료일자 조건 추가

---

## ✅ 작업 내용
- [ ] 읽지 않은 알림 갯수 카운트시 만료일자 조건 추가


---

## 📎 연관된 Issue 번호

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
