### PR TITLE
feat: 사용자 닉네임, 마스킹된 이메일 반환

### DIFF
--- a/user/src/main/java/com/dev_high/user/user/application/dto/UserNicknameEmailCommand.java
+++ b/user/src/main/java/com/dev_high/user/user/application/dto/UserNicknameEmailCommand.java
@@ -1,0 +1,8 @@
+package com.dev_high.user.user.application.dto;
+
+import java.util.List;
+
+public record UserNicknameEmailCommand(
+        List<String> userIds
+) {
+}

--- a/user/src/main/java/com/dev_high/user/user/application/dto/UserNicknameEmailResponse.java
+++ b/user/src/main/java/com/dev_high/user/user/application/dto/UserNicknameEmailResponse.java
@@ -1,0 +1,14 @@
+package com.dev_high.user.user.application.dto;
+
+import com.dev_high.user.user.util.EmailMasker;
+
+public record UserNicknameEmailResponse(
+        String userId,
+        String maskedEmail,
+        String nickname
+) {
+
+    public static UserNicknameEmailResponse of(String userId, String email, String nickname) {
+        return new UserNicknameEmailResponse(userId, EmailMasker.mask(email), nickname);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/user/domain/User.java
+++ b/user/src/main/java/com/dev_high/user/user/domain/User.java
@@ -4,7 +4,6 @@ import com.dev_high.common.annotation.CustomGeneratedId;
 import com.dev_high.user.auth.application.dto.SocialProfileResponse;
 import com.dev_high.user.user.application.dto.UpdateUserCommand;
 import jakarta.persistence.*;
-
 import java.time.OffsetDateTime;
 import lombok.Getter;
 

--- a/user/src/main/java/com/dev_high/user/user/domain/UserRepository.java
+++ b/user/src/main/java/com/dev_high/user/user/domain/UserRepository.java
@@ -1,5 +1,6 @@
 package com.dev_high.user.user.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository {
@@ -9,4 +10,5 @@ public interface UserRepository {
     Optional<User> findByEmailAndDeletedYn(String email, String deletedYn);
     boolean existsByEmailAndDeletedYn(String email, String deletedYn);
     Optional<User> findByProviderAndProviderUserIdAndDeletedYn(OAuthProvider provider, String s, String deletedYn);
+    List<User> findByUserIds(List<String> userIds);
 }

--- a/user/src/main/java/com/dev_high/user/user/infrastructure/UserJpaRepository.java
+++ b/user/src/main/java/com/dev_high/user/user/infrastructure/UserJpaRepository.java
@@ -4,6 +4,7 @@ import com.dev_high.user.user.domain.OAuthProvider;
 import com.dev_high.user.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserJpaRepository extends JpaRepository<User, String> {
@@ -15,4 +16,5 @@ public interface UserJpaRepository extends JpaRepository<User, String> {
             String userId,
             String deletedYn
     );
+    List<User> findByIdIn(List<String> userIds);
 }

--- a/user/src/main/java/com/dev_high/user/user/infrastructure/UserRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/user/infrastructure/UserRepositoryAdapter.java
@@ -4,7 +4,7 @@ import com.dev_high.user.user.domain.OAuthProvider;
 import com.dev_high.user.user.domain.User;
 import com.dev_high.user.user.domain.UserRepository;
 import org.springframework.stereotype.Repository;
-
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -39,5 +39,10 @@ public class UserRepositoryAdapter implements UserRepository {
     @Override
     public Optional<User> findByProviderAndProviderUserIdAndDeletedYn(OAuthProvider provider, String userId, String deletedYn) {
         return userJpaRepository.findByProviderAndProviderUserIdAndDeletedYn(provider, userId, deletedYn);
+    }
+
+    @Override
+    public List<User> findByUserIds(List<String> userIds) {
+        return userJpaRepository.findByIdIn(userIds);
     }
 }

--- a/user/src/main/java/com/dev_high/user/user/presentation/UserController.java
+++ b/user/src/main/java/com/dev_high/user/user/presentation/UserController.java
@@ -2,13 +2,17 @@ package com.dev_high.user.user.presentation;
 
 import com.dev_high.common.dto.ApiResponseDto;
 import com.dev_high.user.user.application.UserService;
+import com.dev_high.user.user.application.dto.UserNicknameEmailResponse;
 import com.dev_high.user.user.application.dto.UserResponse;
 import com.dev_high.user.user.presentation.dto.PasswordUpdateRequest;
+import com.dev_high.user.user.presentation.dto.UserNicknameEmailRequest;
 import com.dev_high.user.user.presentation.dto.UserSignUpRequest;
 import com.dev_high.user.user.presentation.dto.UserUpdateRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RequestMapping("/api/v1/users")
 @RestController
@@ -41,6 +45,11 @@ public class UserController {
     @DeleteMapping
     public ApiResponseDto<Void> deleteUser(){
         return userService.delete();
+    }
+
+    @PostMapping("")
+    public ApiResponseDto<List<UserNicknameEmailResponse>> getUserNicknameAndEmail(@RequestBody UserNicknameEmailRequest request) {
+        return userService.getUserNicknameAndEmail(request.toCommand());
     }
 
     }

--- a/user/src/main/java/com/dev_high/user/user/presentation/dto/UserNicknameEmailRequest.java
+++ b/user/src/main/java/com/dev_high/user/user/presentation/dto/UserNicknameEmailRequest.java
@@ -1,0 +1,12 @@
+package com.dev_high.user.user.presentation.dto;
+
+import com.dev_high.user.user.application.dto.UserNicknameEmailCommand;
+import java.util.List;
+
+public record UserNicknameEmailRequest(
+        List<String> userIds
+) {
+    public UserNicknameEmailCommand toCommand() {
+        return new UserNicknameEmailCommand(userIds);
+    }
+}

--- a/user/src/main/java/com/dev_high/user/user/util/EmailMasker.java
+++ b/user/src/main/java/com/dev_high/user/user/util/EmailMasker.java
@@ -1,0 +1,24 @@
+package com.dev_high.user.user.util;
+
+public final class EmailMasker {
+    private EmailMasker() {}
+
+    public static String mask(String email) {
+        if (email == null || email.isBlank()) {
+            return email;
+        }
+
+        String[] parts = email.split("@");
+
+        String local = parts[0];
+        String domain = parts[1];
+
+        if (local.length() <= 3) {
+            return email;
+        }
+
+        return local.substring(0, 3) +
+                "*".repeat(Math.max(0, local.length() - 3)) +
+                '@' + domain;
+    }
+}


### PR DESCRIPTION
## 📄 배경
- 사용자 id 리스트를 받으면 닉네임, 마스킹된 이메일을 반환하는 API가 존재하지 않음

---

## 🎯 의도
- 사용자 id 리스트를 받으면 닉네임, 마스킹된 이메일을 반환하는 API 추가

---

## ✅ 작업 내용
- [x] 사용자 id 리스트를 받으면 닉네임, 마스킹된 이메일을 반환하는 API 추가

---

## 📎 연관된 Issue 번호
closed #254

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
