### PR TITLE
fix: 유사도 검색시 return하는 source key 추가

### DIFF
--- a/search/src/main/java/com/dev_high/search/application/SearchService.java
+++ b/search/src/main/java/com/dev_high/search/application/SearchService.java
@@ -213,7 +213,7 @@ public class SearchService {
                                     .k(k)
                                     .numCandidates(numCandidates)
                             )
-                            .source(src -> src.filter(f -> f.includes("productId")))
+                            .source(src -> src.filter(f -> f.includes("productId","auctionId","imageUrl")))
                     , ProductDocument.class);
         } catch (Exception e) {
             log.warn("similar search failed: {}", e.getMessage());


### PR DESCRIPTION
## 📄 배경
이 PR이 필요하게 된 배경을 설명해 주세요.

- 유사도 검색시 필요한 필드 못가져오는 현상
- source filter에서 productId 만 리턴하고 있었음.
- 필터

---

## 🎯 의도
이 PR을 통해 달성하고자 하는 목표를 작성해 주세요.

- source filter에서 productId 이외 경매아이디 ,이미지 url추가
- 필요시 엠베딩만 필터하고  전부 허용

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [X] source filter > productId ,auctionId, iamgeUrl 추가
- [ ] 
- [ ] 

---

## 📎 연관된 Issue 번호
<!-- closed #번호 -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
@qkforest 
