### PR TITLE
feat: 챗봇상품추천 시 file정보반환+랜덤추천 시 redis의 auction ranking 조회

### DIFF
--- a/common/src/main/java/com/dev_high/common/config/PromptTemplateConfig.java
+++ b/common/src/main/java/com/dev_high/common/config/PromptTemplateConfig.java
@@ -165,6 +165,7 @@ public class PromptTemplateConfig {
 			의도(intent)는 반드시 아래 중 하나여야 한다.
 			- GREETING: 인사
 			- PRODUCT: 상품 문의, 추천, 비교, 구매 관련 질문
+			- GENERIC_RECOMMENDATION: 조건 없이 아무거나 추천 요청
 			- SERVICE: 배송, 결제, 환불, 계정, 이용 방법 문의
 			- NON_PRODUCT: 상품과 직접 관련 없는 일반 질문
 			- OFF_TOPIC: 서비스 목적과 무관하거나 엉뚱한 질문
@@ -173,6 +174,7 @@ public class PromptTemplateConfig {
 			규칙:
 			- intent는 반드시 하나만 선택하라
 			- 욕설이나 공격적인 표현이 있으면 다른 조건보다 ABUSIVE를 우선한다
+			- 조건/필터 없이 "아무거나 추천", "랜덤 추천", "요즘 뭐 추천", "인기 상품 추천"처럼 구체 조건 없이 추천을 요청하면 GENERIC_RECOMMENDATION을 선택한다
 			- answer는 한국어로 1~3문장으로 작성하라
 			- 장황한 설명이나 불필요한 말은 하지 마라
 			- 사과가 필요한 경우에만 간단히 사과하라

--- a/config/config/product-service.yml
+++ b/config/config/product-service.yml
@@ -1,4 +1,8 @@
 spring:
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
   servlet:
     multipart:
       max-file-size: 20MB     # 파일 하나의 최대 용량

--- a/product/build.gradle
+++ b/product/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 //    implementation 'org.springframework.ai:spring-ai-starter-model-openai'
     implementation 'org.springframework.ai:spring-ai-starter-vector-store-pgvector'

--- a/product/src/main/java/com/dev_high/product/application/dto/IntentType.java
+++ b/product/src/main/java/com/dev_high/product/application/dto/IntentType.java
@@ -6,6 +6,7 @@ public enum IntentType {
 
     GREETING("인사"),
     PRODUCT("상품 문의"),
+    GENERIC_RECOMMENDATION("범용 추천 요청"),
     SERVICE("서비스 문의"),
     NON_PRODUCT("비상품 질문"),
     OFF_TOPIC("주제 외 질문"),

--- a/product/src/main/java/com/dev_high/product/application/dto/ProductAnswer.java
+++ b/product/src/main/java/com/dev_high/product/application/dto/ProductAnswer.java
@@ -2,5 +2,5 @@ package com.dev_high.product.application.dto;
 
 import java.util.List;
 
-public record ProductAnswer(String answer, List<ProductSearchInfo> contexts) { }
+public record ProductAnswer(String answer, List<ProductSearchInfo> contexts, List<FileGroupResponse> fileGroupResponse) { }
 

--- a/product/src/main/java/com/dev_high/product/application/dto/ProductSearchInfo.java
+++ b/product/src/main/java/com/dev_high/product/application/dto/ProductSearchInfo.java
@@ -1,14 +1,17 @@
 package com.dev_high.product.application.dto;
 
+import com.dev_high.product.domain.Category;
+import com.dev_high.product.domain.Product;
 import org.springframework.ai.document.Document;
-
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public record ProductSearchInfo(
         String productId,
         String name,
         String description,
         String sellerId,
+        String fileGroupId,
         String categories,
         String deletedYn) {
 
@@ -21,8 +24,25 @@ public record ProductSearchInfo(
                 (String) metadata.get("name"),
                 (String) metadata.get("description"),
                 (String) metadata.get("sellerId"),
+                (String) metadata.get("FileGroupId"),
                 (String) metadata.get("categories"),
                 (String) metadata.get("deletedYn")
+        );
+    }
+
+    public static ProductSearchInfo from(Product product) {
+        String categories = product.getCategories().stream()
+                .map(Category::getCategoryName)
+                .collect(Collectors.joining(", "));
+
+        return new ProductSearchInfo(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getSellerId(),
+                product.getFileId(),
+                categories,
+                product.getDeletedYn().name()
         );
     }
 }

--- a/product/src/main/resources/application.yml
+++ b/product/src/main/resources/application.yml
@@ -24,7 +24,11 @@ spring:
         dimensions: 1536
         id-type: TEXT
         initialize-schema: false
-
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      database: 1
 ---
 spring:
   config:


### PR DESCRIPTION
## 📄 배경
이 PR이 필요하게 된 배경을 설명해 주세요.

chatbot에서 상품추천 시 상품이미지를 함께 보여주기
랜덤추천을 바라는 요청에는 기존에는 계속 구체적인 답변을 바라는 내용포함

---

## 🎯 의도
이 PR을 통해 달성하고자 하는 목표를 작성해 주세요.

-chatbot 상품 response 시 상품이미지 보여주기
-랜덤추천을 바라는 요청에는 경매조회랭킹 순으로 product 보여주기

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [ ]  product 내에 redis의 auction ranking과 auction summary 조회하는 기능 추가
- [ ] 아무거나 추천해달라는 요청 시 auction ranking에 따라 productSearInfo 반환하도록 조치
- [ ] 챗봇 상품 추천 시 fileGroupResponse를 반환하도록 조치

---

## 📎 연관된 Issue 번호
<!-- closed #281 번호 -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
