### PR TITLE
fix: ES에 아직 인덱싱되지 않은 상품에 대해 경매 정보를 등록할 경우 재시도 로직 추가

### DIFF
--- a/search/src/main/java/com/dev_high/search/admin/presentation/AdminService.java
+++ b/search/src/main/java/com/dev_high/search/admin/presentation/AdminService.java
@@ -6,6 +6,7 @@ import com.dev_high.common.kafka.event.product.ProductCreateSearchRequestEvent;
 import com.dev_high.common.kafka.event.product.ProductUpdateSearchRequestEvent;
 import com.dev_high.search.application.SearchService;
 import com.dev_high.search.domain.ProductDocument;
+import com.dev_high.search.exception.SearchDocumentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
@@ -67,13 +68,21 @@ public class AdminService {
 
 
     public ApiResponseDto<ProductDocument> updateByProduct(ProductUpdateSearchRequestEvent request) {
-        ProductDocument document = searchService.updateByProduct(request);
-        return ApiResponseDto.success(document);
+        try {
+            ProductDocument document = searchService.updateByProduct(request);
+            return ApiResponseDto.success(document);
+        } catch (SearchDocumentNotFoundException e) {
+            return ApiResponseDto.fail(e.getMessage());
+        }
     }
 
     public ApiResponseDto<ProductDocument> updateByAuction(AuctionUpdateSearchRequestEvent request) {
-        ProductDocument document = searchService.updateByAuction(request);
-        return ApiResponseDto.success(document);
+        try {
+            ProductDocument document = searchService.updateByAuction(request);
+            return ApiResponseDto.success(document);
+        } catch (SearchDocumentNotFoundException e) {
+            return ApiResponseDto.fail(e.getMessage());
+        }
     }
 
     public ApiResponseDto<Void> deleteByProduct(String productId) {

--- a/search/src/main/java/com/dev_high/search/exception/SearchDocumentNotFoundException.java
+++ b/search/src/main/java/com/dev_high/search/exception/SearchDocumentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dev_high.search.exception;
+
+public class SearchDocumentNotFoundException extends Exception {
+    public SearchDocumentNotFoundException(String productId) {
+        super(String.format("SearchDocumentNotFound: productId=%s", productId));
+    }
+}


### PR DESCRIPTION
## 📄 배경

- 현재 상품 정보가 먼저 인덱싱 되고 그 후에 경매 정보가 추가로 저장되는 구조로 동작한다
- 딜레이로 인해 아직 인덱싱 되지 앟은 상품에 대해 경매 정보를 등록할 경우 재시도 로직이 필요하다.

---

## 🎯 의도

- 경매 정보를 등록하기 위해 상품 id로 문서를 조회할 때 아직 문서가 등록되지 않아 조회할 수 없는 경우,
kafka에서 재시도 하도록 custom error 생성
- 현재는 오류가 발생하면 5초 기다렸다 재시도 -> kafka 재시도 전에 내부적으로 기다렸다 재조회하는 로직 추가

---

## ✅ 작업 내용

- [x] 아직 문서가 등록되지 않아 상품 아이디로 조회할 수 없는 경우 발생하는 custom error 생성
- [x] search 서비스 내부에서 짧게 기다렸다 조회 재시도하는 로직 추가


---

## 📎 연관된 Issue 번호
 closed #299

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
