### PR TITLE
feat: refreshToken 저장 방식 변경에 따른 중복 로그인 허용

### DIFF
--- a/user/src/main/java/com/dev_high/user/auth/domain/RefreshToken.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/RefreshToken.java
@@ -14,16 +14,16 @@ import org.springframework.data.redis.core.TimeToLive;
 public class RefreshToken {
 
     @Id
-    private String userId;
-
     private String token;
+
+    private String userId;
 
     @TimeToLive
     private Long ttl; // 초 단위 TTL
 
-    public RefreshToken(String userId, String token, Long ttl) {
-        this.userId = userId;
+    public RefreshToken(String token, String userId, Long ttl) {
         this.token = token;
+        this.userId = userId;
         this.ttl = ttl;
     }
 }

--- a/user/src/main/java/com/dev_high/user/auth/domain/RefreshTokenRepository.java
+++ b/user/src/main/java/com/dev_high/user/auth/domain/RefreshTokenRepository.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository {
     void save(String userId, String refreshToken, long ttlMilliseconds);
-    Optional<RefreshToken> findByUserId(String userId);
-    void deleteById(String token);
-
+    Optional<RefreshToken> findById(String refreshToken);
+    void deleteById(String refreshToken);
 }

--- a/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenRepositoryAdapter.java
+++ b/user/src/main/java/com/dev_high/user/auth/infrastructure/RefreshTokenRepositoryAdapter.java
@@ -21,12 +21,12 @@ public class RefreshTokenRepositoryAdapter implements RefreshTokenRepository {
     }
 
     @Override
-    public Optional<RefreshToken> findByUserId(String userId) {
-        return refreshTokenCrudRepository.findById(userId);
+    public Optional<RefreshToken> findById(String refreshToken) {
+        return refreshTokenCrudRepository.findById(refreshToken);
     }
 
     @Override
-    public void deleteById(String userId) {
-        refreshTokenCrudRepository.deleteById(userId);
+    public void deleteById(String refreshToken) {
+        refreshTokenCrudRepository.deleteById(refreshToken);
     }
 }


### PR DESCRIPTION
## 📄 배경

- refresh 토큰 저장을 userId(redis key)로 해서 중복 로그인이 불가능

---

## 🎯 의도

- redis 저장 key 값을 refresh token으로 함
---

## ✅ 작업 내용

- [x] redis 저장 key 값을 refresh token으로 변경

