### PR TITLE
Feat/#303 결제

### DIFF
--- a/common/src/main/java/com/dev_high/common/kafka/event/NotificationRequestEvent.java
+++ b/common/src/main/java/com/dev_high/common/kafka/event/NotificationRequestEvent.java
@@ -10,5 +10,8 @@ public record NotificationRequestEvent(
     String redirectUrl,
     NotificationCategory.Type type
 ) {
+    public static NotificationRequestEvent of(List<String> userIds, String message, String redirectUrl, NotificationCategory.Type type) {
+        return new NotificationRequestEvent(userIds, message, redirectUrl, type);
+    }
 
 }

--- a/common/src/main/java/com/dev_high/common/type/NotificationCategory.java
+++ b/common/src/main/java/com/dev_high/common/type/NotificationCategory.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Getter
 public enum NotificationCategory {
     AUCTION(List.of(Type.AUCTION_NO_BID, Type.AUCTION_CLOSED)),
-    DEPOSIT(List.of(Type.DEPOSIT)),
+    PAYMENT(List.of(Type.PAYMENT_COMPLETED, Type.DEPOSIT_CHARGE_COMPLETED)),
     ORDER(List.of(Type.ORDER_CREATED, Type.ORDER_STARTED, Type.ORDER_COMPLETED, Type.ORDER_CANCELED)),
     PRODUCT(List.of(Type.PRODUCT)),
     SEARCH(List.of(Type.SEARCH)),
@@ -32,7 +32,8 @@ public enum NotificationCategory {
     public enum Type {
         AUCTION_NO_BID("경매 유찰"),
         AUCTION_CLOSED("경매 종료"),
-        DEPOSIT("예치금"),
+        PAYMENT_COMPLETED("주문 결제 완료"),
+        DEPOSIT_CHARGE_COMPLETED("예치금 충전 완료"),
         ORDER_CREATED("주문 생성"),
         ORDER_STARTED("배송중"),
         ORDER_COMPLETED("배송 완료"),

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
@@ -163,6 +163,10 @@ public class DepositOrderService {
         }
         orderRepository.save(order);
         log.info("[PaymentOrder] cancelledOrder success. orderId={}, cancelReason={}, status={}", command.id(), command.cancelReason(), order.getStatus());
+        if (order.getType() == DepositOrderType.ORDER_PAYMENT) {
+            log.info("[PaymentOrder] Publishing OrderCancelled event. orderId={}", order.getId());
+            applicationEventPublisher.publishEvent(OrderEvent.OrderCancelled.of(command.cancelReason()));
+        }
         return DepositOrderDto.Info.from(order);
     }
 

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
@@ -5,6 +5,7 @@ import com.dev_high.common.dto.ApiResponseDto;
 import com.dev_high.common.type.DepositOrderStatus;
 import com.dev_high.common.type.DepositOrderType;
 import com.dev_high.common.type.DepositType;
+import com.dev_high.common.type.NotificationCategory;
 import com.dev_high.common.util.HttpUtil;
 import com.dev_high.deposit.order.application.dto.DepositOrderDto;
 import com.dev_high.deposit.order.application.event.OrderEvent;
@@ -26,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @Service
@@ -120,6 +122,7 @@ public class DepositOrderService {
         } else if(order.getType() == DepositOrderType.ORDER_PAYMENT) {
             log.info("[PaymentOrder] Publishing OrderCompleted event. orderId={}, winningOrderId={}", order.getId(), command.winningOrderId());
             applicationEventPublisher.publishEvent(OrderEvent.OrderCompleted.of(command.winningOrderId(), order.getId()));
+            publishOrderNotification(order, order.getType(), "CONFIRM");
         }
     }
 
@@ -166,6 +169,7 @@ public class DepositOrderService {
         if (order.getType() == DepositOrderType.ORDER_PAYMENT) {
             log.info("[PaymentOrder] Publishing OrderCancelled event. orderId={}", order.getId());
             applicationEventPublisher.publishEvent(OrderEvent.OrderCancelled.of(command.cancelReason()));
+            publishOrderNotification(order, order.getType(), "CANCEL");
         }
         return DepositOrderDto.Info.from(order);
     }
@@ -228,7 +232,9 @@ public class DepositOrderService {
             order.ChangeStatus(DepositOrderStatus.DEPOSIT_APPLIED);
         } else {
             order.ChangeStatus(DepositOrderStatus.COMPLETED);
+            log.info("[PaymentOrder] Publishing OrderCompleted event. orderId={}, winningOrderId={}", order.getId(),winningOrderId);
             applicationEventPublisher.publishEvent(OrderEvent.OrderCompleted.of(winningOrderId, order.getId()));
+            publishOrderNotification(order, order.getType(), "CONFIRM");
         }
     }
 
@@ -238,5 +244,30 @@ public class DepositOrderService {
         } else if(order.getType() == DepositOrderType.ORDER_PAYMENT) {
             order.ChangeStatus(DepositOrderStatus.COMPLETED);
         }
+    }
+
+    private void publishOrderNotification(DepositOrder order, DepositOrderType oderType, String type) {
+        String message = switch (type) {
+            case "CONFIRM" -> switch (oderType) {
+                case DEPOSIT_CHARGE -> "충전이 완료되었습니다.";
+                case ORDER_PAYMENT -> "결제가 완료되었습니다.";
+            };
+            case "CANCEL" -> switch (oderType) {
+                case DEPOSIT_CHARGE -> "충전이 취소되었습니다.";
+                case ORDER_PAYMENT -> "결제가 취소되었습니다.";
+            };
+            default -> throw new IllegalStateException("허용되지 않는 type 입니다: " + type);
+        };
+        String redirectUrl = switch (oderType) {
+            case DEPOSIT_CHARGE -> "/mypage?tab=0";
+            case ORDER_PAYMENT -> "/mypage?tab=1";
+        };
+
+        NotificationCategory.Type notificationType = switch (oderType) {
+            case DEPOSIT_CHARGE -> NotificationCategory.Type.DEPOSIT_CHARGE_COMPLETED;
+            case ORDER_PAYMENT -> NotificationCategory.Type.PAYMENT_COMPLETED;
+        };
+        log.info("[PaymentOrder] Publishing publishOrderNotification event. orderId={}, oderType={}, type={}, notificationType={}, message={}", order.getId(), oderType, type, notificationType, message);
+        applicationEventPublisher.publishEvent(OrderEvent.OrderNotification.of(List.of(order.getUserId()), message, redirectUrl, notificationType));
     }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEvent.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEvent.java
@@ -9,4 +9,12 @@ public class OrderEvent {
             return new OrderCompleted(winningOrderId, orderId);
         }
     }
+
+    public record OrderCancelled(
+        String orderId
+    ) {
+        public static OrderCancelled of(String orderId) {
+            return new OrderCancelled(orderId);
+        }
+    }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEvent.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEvent.java
@@ -1,5 +1,9 @@
 package com.dev_high.deposit.order.application.event;
 
+import com.dev_high.common.type.NotificationCategory;
+
+import java.util.List;
+
 public class OrderEvent {
     public record OrderCompleted(
             String winningOrderId,
@@ -15,6 +19,17 @@ public class OrderEvent {
     ) {
         public static OrderCancelled of(String orderId) {
             return new OrderCancelled(orderId);
+        }
+    }
+
+    public record OrderNotification(
+            List<String> userIds,
+            String message,
+            String redirectUrl,
+            NotificationCategory.Type type
+    ) {
+        public static OrderNotification of(List<String> userIds, String message, String redirectUrl, NotificationCategory.Type type) {
+            return new OrderNotification(userIds, message, redirectUrl, type);
         }
     }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEventHandler.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEventHandler.java
@@ -19,4 +19,9 @@ public class OrderEventHandler {
     public void handlerDepositPaid(OrderEvent.OrderCompleted event) {
         kafkaEventPublisher.publish(KafkaTopics.DEPOSIT_ORDER_COMPLETE_RESPONSE, DepositOrderCompletedEvent.of(event.winningOrderId(), event.orderId(), "PAID"));
     }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlerPaymentPaid(OrderEvent.OrderCancelled event) {
+        kafkaEventPublisher.publish(KafkaTopics.DEPOSIT_ORDER_COMPLETE_RESPONSE, DepositOrderCompletedEvent.of("", event.orderId(), "PAID_CANCEL"));
+    }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEventHandler.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/event/OrderEventHandler.java
@@ -1,6 +1,7 @@
 package com.dev_high.deposit.order.application.event;
 
 import com.dev_high.common.kafka.KafkaEventPublisher;
+import com.dev_high.common.kafka.event.NotificationRequestEvent;
 import com.dev_high.common.kafka.event.deposit.DepositOrderCompletedEvent;
 import com.dev_high.common.kafka.topics.KafkaTopics;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +24,10 @@ public class OrderEventHandler {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlerPaymentPaid(OrderEvent.OrderCancelled event) {
         kafkaEventPublisher.publish(KafkaTopics.DEPOSIT_ORDER_COMPLETE_RESPONSE, DepositOrderCompletedEvent.of("", event.orderId(), "PAID_CANCEL"));
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlerOrderNotification(OrderEvent.OrderNotification event) {
+        kafkaEventPublisher.publish(KafkaTopics.NOTIFICATION_REQUEST, NotificationRequestEvent.of(event.userIds(), event.message(), event.redirectUrl(), event.type()));
     }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/payment/application/DepositPaymentService.java
+++ b/deposit/src/main/java/com/dev_high/deposit/payment/application/DepositPaymentService.java
@@ -172,7 +172,7 @@ public class DepositPaymentService {
         log.info("[Payment] cancelPayment start. orderId={}, cancelReason={}", command.orderId(), command.cancelReason());
         DepositPayment payment = loadPayment(command.orderId());
         payment.applyCancelledStatus();
-        TossPaymentResponse tossPayment = tossPaymentCancel(DepositPaymentDto.CancelRequestCommand.of(payment.getOrderId(), payment.getPaymentKey(), command.cancelReason()));
+        TossPaymentResponse tossPayment = tossPaymentCancel(DepositPaymentDto.CancelRequestCommand.of(payment.getOrderId(), payment.getPaymentKey(), command.cancelReason(), payment.getAmount(), payment.getUserId()));
         TossCancel tossPaymentCancel = extractCancel(tossPayment);
         compareAmount(payment.getAmount(), tossPaymentCancel.cancelAmount());
 
@@ -202,7 +202,8 @@ public class DepositPaymentService {
     }
 
     private void handleCancelHttpException(HttpStatusCodeException e, DepositPaymentDto.CancelRequestCommand command) {
-        handleTossHttpException(e, command.orderId(), "취소", null);
+        handleTossHttpException(e, command.orderId(), "취소",
+                (code, message) -> handlePaymentFailure(command.orderId(), command.userId(), command.amount(), code, message));
     }
 
     private void handleTossHttpException(HttpStatusCodeException e, String orderId, String actionName, BiConsumer<String, String> failureHandler) {

--- a/deposit/src/main/java/com/dev_high/deposit/payment/application/dto/DepositPaymentDto.java
+++ b/deposit/src/main/java/com/dev_high/deposit/payment/application/dto/DepositPaymentDto.java
@@ -40,10 +40,12 @@ public class DepositPaymentDto {
     public record CancelRequestCommand(
             String orderId,
             String paymentKey,
-            String cancelReason
+            String cancelReason,
+            BigDecimal amount,
+            String userId
     ) {
-        public static CancelRequestCommand of(String orderId, String paymentKey, String cancelReason) {
-            return new CancelRequestCommand(orderId, paymentKey, cancelReason);
+        public static CancelRequestCommand of(String orderId, String paymentKey, String cancelReason, BigDecimal amount, String userId) {
+            return new CancelRequestCommand(orderId, paymentKey, cancelReason, amount, userId);
         }
     }
 


### PR DESCRIPTION
## 📄 배경
결제서비스 알림 추가
결제 취소후 경매쪽에 취소 카프카 알림

---

## 🎯 의도
결제서비스 알림 추가
결제 취소후 경매쪽에 취소 카프카 알림

---

## ✅ 작업 내용
- [ ] 결제주문 취소시 주문서비스에 결제취소 상태 알림 추가
- [ ] 결제서비스 알림 추가
- [ ] 결제취소 로직 조건 수정
- [ ] 주문취소 실패시 히스토리 로그 쌓는 로직 추가

---

## 📎 연관된 Issue 번호
<!-- closed #번호 -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
