### PR TITLE
refactor: 주문취소 대기처리 API 추가, 주문취소 시 주문취소대기 상태허용 포함

### DIFF
--- a/common/src/main/java/com/dev_high/common/type/DepositOrderStatus.java
+++ b/common/src/main/java/com/dev_high/common/type/DepositOrderStatus.java
@@ -9,6 +9,7 @@ package com.dev_high.common.type;
  * COMPLETED : 충전 완료 (충전/환불 성공)
  * FAILED : 실패 (결제 실패)
  * CANCELLED : 취소 (사용자 요청에 의한 취소)
+ * CANCEL_PENDING : 취소 대기
  * DEPOSIT_APPLIED_ERROR : 예치금 처리 에러발생
  * PAYMENT_CONFIRMED_ERROR : 결제 승인처리 에러발생
  * */
@@ -20,6 +21,7 @@ public enum DepositOrderStatus {
     COMPLETED,
     FAILED,
     CANCELLED,
+    CANCEL_PENDING,
     DEPOSIT_APPLIED_ERROR,
     PAYMENT_CONFIRMED_ERROR
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/DepositOrderService.java
@@ -178,6 +178,16 @@ public class DepositOrderService {
         return DepositOrderDto.Info.from(order);
     }
 
+    @Transactional
+    public DepositOrderDto.Info cancelPendingOrder(DepositOrderDto.CancelPendingCommand command) {
+        log.info("[PaymentOrder] cancelPendingOrder start. orderId={}", command.id());
+        DepositOrder order = loadOrder(command.id());
+        order.applyCancelFendingStatus();
+        orderRepository.save(order);
+        log.info("[PaymentOrder] cancelPendingOrder success. orderId={}, status={}", command.id(), order.getStatus());
+        return DepositOrderDto.Info.from(order);
+    }
+
     private DepositOrder loadOrder(String orderId) {
         return orderRepository.findById(orderId)
                 .orElseThrow(() -> {

--- a/deposit/src/main/java/com/dev_high/deposit/order/application/dto/DepositOrderDto.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/application/dto/DepositOrderDto.java
@@ -80,6 +80,14 @@ public class DepositOrderDto {
         }
     }
 
+    public record CancelPendingCommand(
+            String id
+    ) {
+        public static CancelPendingCommand of(String id) {
+            return new CancelPendingCommand(id);
+        }
+    }
+
     public record Info(
             String id,
             String userId,

--- a/deposit/src/main/java/com/dev_high/deposit/order/domain/entity/DepositOrder.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/domain/entity/DepositOrder.java
@@ -142,6 +142,11 @@ public class DepositOrder {
         return this.status == DepositOrderStatus.COMPLETED;
     }
 
+    public boolean isCancelable() {
+        return List.of(DepositOrderStatus.COMPLETED, DepositOrderStatus.CANCEL_PENDING)
+                .contains(this.status);
+    }
+
     public void applyConfirmedStatus() {
         if (!isConfirmable()) {
             throw new IllegalArgumentException("결제승인처리를 진행할 수 없는 주문 상태입니다: " + this.status);
@@ -156,10 +161,17 @@ public class DepositOrder {
     }
 
     public void applyCancelledStatus() {
-        if (!isCompleted()) {
-            throw new IllegalArgumentException("결제완료된 주문이 아닙니다. 현재 상태: " +  this.status);
+        if (!isCancelable()) {
+            throw new IllegalArgumentException("결제취소처리를 진행할 수 없는 주문 상태입니다. 현재 상태: " +  this.status);
         }
         this.status = DepositOrderStatus.CANCELLED;
+    }
+
+    public void applyCancelFendingStatus() {
+        if (!isCompleted()) {
+            throw new IllegalArgumentException("결제취소대기처리를 진행할 수 없는 주문 상태입니다. 현재 상태: " +  this.status);
+        }
+        this.status = DepositOrderStatus.CANCEL_PENDING;
     }
 
     public void ChangeStatus(DepositOrderStatus status) {

--- a/deposit/src/main/java/com/dev_high/deposit/order/presentation/DepositOrderController.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/presentation/DepositOrderController.java
@@ -89,4 +89,15 @@ public class DepositOrderController {
         log.info("[PaymentOrder API] PATH : /orders/cancled success. orderId={}, amount={}, deposit={}, paidAmount={}, status={}", response.id(), response.amount(), response.deposit(), response.paidAmount(), response.status());
         return ApiResponseDto.success(response);
     }
+
+    @Operation(summary = "주문 ID의 주문 취소 대기 처리", description = "주문 ID의 주문 취소 대기 처리")
+    @PostMapping("/orders/cancel-pending")
+    public ApiResponseDto<DepositOrderResponse.Detail> cancelPendingOrder(@RequestBody @Valid DepositOrderRequest.CancelPending request) {
+        log.info("[PaymentOrder API] PATH : /orders/cancel-pending request received. id={}", request.id());
+        DepositOrderDto.CancelPendingCommand command = request.toCommand(request.id());
+        DepositOrderDto.Info info = depositOrderService.cancelPendingOrder(command);
+        DepositOrderResponse.Detail response = DepositOrderResponse.Detail.from(info);
+        log.info("[PaymentOrder API] PATH : /orders/cancel-pending success. id={}", request.id());
+        return ApiResponseDto.success(response);
+    }
 }

--- a/deposit/src/main/java/com/dev_high/deposit/order/presentation/dto/DepositOrderRequest.java
+++ b/deposit/src/main/java/com/dev_high/deposit/order/presentation/dto/DepositOrderRequest.java
@@ -75,4 +75,14 @@ public class DepositOrderRequest {
             return DepositOrderDto.CancelCommand.of(id, cancelReason);
         }
     }
+
+    public record CancelPending(
+            @Schema(description = "취소할 주문 ID")
+            @NotBlank(message = "주문 ID는 필수 입니다.")
+            String id
+    ) {
+        public DepositOrderDto.CancelPendingCommand toCommand(String id) {
+            return DepositOrderDto.CancelPendingCommand.of(id);
+        }
+    }
 }


### PR DESCRIPTION
## 📄 배경
주문취소 대기처리 API 추가, 주문취소 시 주문취소대기 상태허용 포함

---

## 🎯 의도
주문취소 대기처리 API 추가, 주문취소 시 주문취소대기 상태허용 포함

---

## ✅ 작업 내용
이번 PR에서 수행한 작업을 체크박스 형태로 작성해 주세요.

- [ ] 주문취소 대기처리 API 추가
- [ ] 주문취소 시 주문취소대기 상태허용 포함
- [ ] 

---

## 📎 연관된 Issue 번호
<!-- closed #번호 -->

---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
