### PR TITLE
feat: 탈퇴 시 소셜 계정 연동 해제 및 정보 삭제, ES 내 임베딩 형식 변경 및 상품 정보 전처리 추가

### DIFF
--- a/search/src/main/java/com/dev_high/search/util/EmbeddingTextPreprocessor.java
+++ b/search/src/main/java/com/dev_high/search/util/EmbeddingTextPreprocessor.java
@@ -1,0 +1,50 @@
+package com.dev_high.search.util;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+public final class EmbeddingTextPreprocessor {
+
+    private EmbeddingTextPreprocessor() {
+    }
+
+    private static final Pattern MULTI_SPACE = Pattern.compile("[ \\t\\x0B\\f]+");
+
+    private static final Pattern REMOVE_SPECIAL_CHARS = Pattern.compile("[\\[\\]{}()<>•·*\\-‒–—]");
+
+    public static String preprocess(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return "";
+        }
+
+        String[] lines = raw.replace("\uFEFF", "")
+                .replace("\r\n", "\n")
+                .replace("\r", "\n")
+                .split("\n");
+
+        List<String> cleanedLines = new ArrayList<>();
+
+        for (String line : lines) {
+            String l = line.trim();
+
+            if (l.isEmpty()) {
+                continue;
+            }
+
+            l = REMOVE_SPECIAL_CHARS.matcher(l).replaceAll("").trim();
+
+            char lastChar = l.charAt(l.length() - 1);
+            if (lastChar != '.' && lastChar != '!' && lastChar != '?' && lastChar != '…'
+                    && lastChar != '。' && lastChar != '！' && lastChar != '？') {
+                l += ".";
+            }
+
+            cleanedLines.add(l);
+        }
+
+        String result = String.join(" ", cleanedLines);
+        result = MULTI_SPACE.matcher(result).replaceAll(" ").trim();
+
+        return result;
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/application/dto/OAuthTokenResponse.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/dto/OAuthTokenResponse.java
@@ -1,7 +1,8 @@
 package com.dev_high.user.auth.application.dto;
 
-public record AccessTokenResponse(
+public record OAuthTokenResponse(
         String access_token,
+        String refresh_token,
         String expires_in,
         String scope,
         String id_token

--- a/user/src/main/java/com/dev_high/user/auth/application/dto/SocialProfileResponse.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/dto/SocialProfileResponse.java
@@ -5,6 +5,7 @@ import com.dev_high.user.user.domain.OAuthProvider;
 public record SocialProfileResponse(
         OAuthProvider provider,
         String providerUserId,
+        String providerToken,
         String email,
         String name,
         String nickname,

--- a/user/src/main/java/com/dev_high/user/auth/application/oauth/GoogleOAuthService.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/oauth/GoogleOAuthService.java
@@ -1,17 +1,25 @@
 package com.dev_high.user.auth.application.oauth;
 
-import com.dev_high.user.auth.application.dto.AccessTokenResponse;
 import com.dev_high.user.auth.application.dto.GoogleProfileResponse;
+import com.dev_high.user.auth.application.dto.OAuthTokenResponse;
 import com.dev_high.user.auth.application.dto.SocialProfileResponse;
+import com.dev_high.user.auth.exception.OAuthAccessTokenNotFoundException;
+import com.dev_high.user.auth.exception.OAuthProfileInvalidException;
+import com.dev_high.user.auth.exception.OAuthTokenIssueException;
 import com.dev_high.user.user.domain.OAuthProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class GoogleOAuthService implements SocialOAuthService {
@@ -26,7 +34,7 @@ public class GoogleOAuthService implements SocialOAuthService {
     private String googleRedirectUri;
 
     @Override
-    public String getAccessToken(String code){
+    public OAuthTokenResponse getTokens(String code){
         RestClient restClient = RestClient.create();
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
@@ -36,28 +44,68 @@ public class GoogleOAuthService implements SocialOAuthService {
         params.add("redirect_uri", googleRedirectUri);
         params.add("grant_type", "authorization_code");
 
-        ResponseEntity<AccessTokenResponse> response = restClient.post()
+        ResponseEntity<OAuthTokenResponse> response = restClient.post()
                 .uri("https://oauth2.googleapis.com/token")
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .body(params)
                 .retrieve()
-                .toEntity(AccessTokenResponse.class);
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("구글 토큰 발급 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "구글 토큰 발급에 실패했습니다."
+                            );
+                        }
+                )
+                .toEntity(OAuthTokenResponse.class);
 
-        return response.getBody().access_token();
+        OAuthTokenResponse body = response.getBody();
+
+        if(body == null){
+            log.warn("구글 토큰 응답 비어있음. status={}, headers={}", response.getStatusCode(), response.getHeaders());
+            throw new OAuthTokenIssueException();
+        }
+
+        if(body.access_token() == null || body.access_token().isBlank()) {
+            log.warn("구글 access_token 없음. responseBody={}", body);
+            throw new OAuthAccessTokenNotFoundException();
+        }
+
+        return body;
     }
 
     @Override
-    public SocialProfileResponse getProfile(String token){
+    public SocialProfileResponse getProfile(OAuthTokenResponse tokenResponse){
         RestClient restClient = RestClient.create();
+        String token = tokenResponse.access_token();
         ResponseEntity<GoogleProfileResponse> response =  restClient.get()
                 .uri("https://openidconnect.googleapis.com/v1/userinfo")
                 .header("Authorization", "Bearer "+token)
                 .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("구글 사용자 정보 조회 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "구글 사용자 정보를 조회하는 데 실패했습니다."
+                            );
+                        }
+                )
                 .toEntity(GoogleProfileResponse.class);
+
         GoogleProfileResponse googleProfile = response.getBody();
+
+        if (googleProfile == null) {
+            throw new OAuthProfileInvalidException();
+        }
+
         return new SocialProfileResponse(
                 getProvider(),
                 googleProfile.sub(),
+                tokenResponse.refresh_token(),
                 googleProfile.email(),
                 googleProfile.name(),
                 googleProfile.name(),
@@ -68,5 +116,30 @@ public class GoogleOAuthService implements SocialOAuthService {
     @Override
     public OAuthProvider getProvider() {
         return OAuthProvider.GOOGLE;
+    }
+
+    @Override
+    public void unlink(String refreshToken) {
+        RestClient restClient = RestClient.create();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("token", refreshToken);
+
+        restClient.post()
+                .uri("https://oauth2.googleapis.com/revoke")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("구글 계정 연동 해제 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "구글 계정 연동 해제에 실패했습니다."
+                            );
+                        }
+                )
+                .toBodilessEntity();
     }
 }

--- a/user/src/main/java/com/dev_high/user/auth/application/oauth/NaverOAuthService.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/oauth/NaverOAuthService.java
@@ -1,17 +1,24 @@
 package com.dev_high.user.auth.application.oauth;
 
-import com.dev_high.user.auth.application.dto.AccessTokenResponse;
 import com.dev_high.user.auth.application.dto.NaverProfileWrapper;
+import com.dev_high.user.auth.application.dto.OAuthTokenResponse;
 import com.dev_high.user.auth.application.dto.SocialProfileResponse;
+import com.dev_high.user.auth.exception.OAuthAccessTokenNotFoundException;
+import com.dev_high.user.auth.exception.OAuthProfileInvalidException;
+import com.dev_high.user.auth.exception.OAuthTokenIssueException;
 import com.dev_high.user.user.domain.OAuthProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.server.ResponseStatusException;
+import java.util.Optional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class NaverOAuthService implements SocialOAuthService {
@@ -25,43 +32,82 @@ public class NaverOAuthService implements SocialOAuthService {
     private String naverClientSecret;
 
     @Override
-    public String getAccessToken(String code){
+    public OAuthTokenResponse getTokens(String code){
         RestClient restClient = RestClient.create();
 
         String state = oAuthStateContext.getState();
-
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        
         params.add("code", code);
         params.add("client_id", naverClientId);
         params.add("client_secret", naverClientSecret);
         params.add("grant_type", "authorization_code");
         params.add("state", state);
 
-        ResponseEntity<AccessTokenResponse> response = restClient.post()
+        ResponseEntity<OAuthTokenResponse> response = restClient.post()
                 .uri("https://nid.naver.com/oauth2.0/token")
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .body(params)
                 .retrieve()
-                .toEntity(AccessTokenResponse.class);
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("네이버 토큰 발급 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "네이버 토큰 발급에 실패했습니다."
+                            );
+                        }
+                )
+                .toEntity(OAuthTokenResponse.class);
 
-        return response.getBody().access_token();
+        OAuthTokenResponse body = response.getBody();
+
+        if(body == null){
+            log.warn("네이버 토큰 응답 비어있음. status={}, headers={}", response.getStatusCode(), response.getHeaders());
+            throw new OAuthTokenIssueException();
+        }
+
+        if(body.access_token() == null || body.access_token().isBlank()) {
+            log.warn("네이버 access_token 없음. responseBody={}", body);
+            throw new OAuthAccessTokenNotFoundException();
+        }
+
+        return body;
     }
 
     @Override
-    public SocialProfileResponse getProfile(String token){
+    public SocialProfileResponse getProfile(OAuthTokenResponse tokenResponse){
         RestClient restClient = RestClient.create();
+        String token = tokenResponse.access_token();
         ResponseEntity<NaverProfileWrapper> response = restClient.get()
                 .uri("https://openapi.naver.com/v1/nid/me")
                 .header("Authorization", "Bearer " + token)
                 .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("네이버 사용자 정보 조회 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "네이버 사용자 정보를 조회하는 데 실패했습니다."
+                            );
+                        }
+                )
                 .toEntity(NaverProfileWrapper.class);
 
         NaverProfileWrapper body = response.getBody();
+
+        if (body == null || body.response() == null) {
+             throw new OAuthProfileInvalidException();
+        }
+
         NaverProfileWrapper.NaverProfile naverProfile = body.response();
 
         return new SocialProfileResponse(
                 getProvider(),
                 naverProfile.id(),
+                tokenResponse.refresh_token(),
                 naverProfile.email(),
                 naverProfile.name(),
                 naverProfile.nickname(),
@@ -73,4 +119,67 @@ public class NaverOAuthService implements SocialOAuthService {
     public OAuthProvider getProvider() {
         return OAuthProvider.NAVER;
     }
+
+    public void unlink(String refreshToken) {
+        Optional<String> accessToken = getAccessTokenFromRefreshToken(refreshToken);
+        if (accessToken.isEmpty()) {
+            throw new OAuthAccessTokenNotFoundException();
+        }
+
+        RestClient restClient = RestClient.create();
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+
+        params.add("grant_type", "delete");
+        params.add("client_id", naverClientId);
+        params.add("client_secret", naverClientSecret);
+        params.add("access_token", accessToken.get());
+        params.add("service_provider", "NAVER");
+
+        restClient.post()
+                .uri("https://nid.naver.com/oauth2.0/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(params)
+                .retrieve()
+                .onStatus(
+                        HttpStatusCode::isError,
+                        (req, res) -> {
+                            log.warn("네이버 계정 연동 해제 실패. status={}", res.getStatusCode());
+                            throw new ResponseStatusException(
+                                    res.getStatusCode(),
+                                    "네이버 계정 연동 해제에 실패했습니다."
+                            );
+                        }
+                )
+                .toBodilessEntity();
+    }
+
+    private Optional<String> getAccessTokenFromRefreshToken(String refreshToken) {
+        RestClient restClient = RestClient.create();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "refresh_token");
+        params.add("client_id", naverClientId);
+        params.add("client_secret", naverClientSecret);
+        params.add("refresh_token", refreshToken);
+
+        return Optional.ofNullable(
+                restClient.post()
+                    .uri("https://nid.naver.com/oauth2.0/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .onStatus(
+                            HttpStatusCode::isError,
+                            (req, res) -> {
+                                log.warn("네이버 토큰 갱신 실패. status={}", res.getStatusCode());
+                                throw new ResponseStatusException(
+                                        res.getStatusCode(),
+                                        "네이버 토큰 갱신에 실패했습니다."
+                                );
+                            }
+                    )
+                    .body(OAuthTokenResponse.class)
+                    ).map(OAuthTokenResponse::access_token);
+    }
+
 }

--- a/user/src/main/java/com/dev_high/user/auth/application/oauth/SocialOAuthService.java
+++ b/user/src/main/java/com/dev_high/user/auth/application/oauth/SocialOAuthService.java
@@ -1,10 +1,12 @@
 package com.dev_high.user.auth.application.oauth;
 
+import com.dev_high.user.auth.application.dto.OAuthTokenResponse;
 import com.dev_high.user.auth.application.dto.SocialProfileResponse;
 import com.dev_high.user.user.domain.OAuthProvider;
 
 public interface SocialOAuthService {
-    String getAccessToken(String code);
-    SocialProfileResponse getProfile(String accessToken);
+    OAuthTokenResponse getTokens(String code);
+    SocialProfileResponse getProfile(OAuthTokenResponse tokenResponse);
     OAuthProvider getProvider();
+    void unlink(String refreshToken);
 }

--- a/user/src/main/java/com/dev_high/user/auth/exception/OAuthAccessTokenNotFoundException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/OAuthAccessTokenNotFoundException.java
@@ -1,0 +1,13 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class OAuthAccessTokenNotFoundException  extends CustomException {
+    public OAuthAccessTokenNotFoundException() {
+        super(
+                HttpStatus.BAD_REQUEST,
+                "소셜 로그인 인증 정보가 유효하지 않습니다."
+        );
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/exception/OAuthProfileInvalidException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/OAuthProfileInvalidException.java
@@ -1,0 +1,14 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class OAuthProfileInvalidException extends CustomException {
+
+    public OAuthProfileInvalidException() {
+        super(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "소셜 로그인 사용자 정보 응답이 올바르지 않습니다."
+        );
+    }
+}

--- a/user/src/main/java/com/dev_high/user/auth/exception/OAuthTokenIssueException.java
+++ b/user/src/main/java/com/dev_high/user/auth/exception/OAuthTokenIssueException.java
@@ -1,0 +1,14 @@
+package com.dev_high.user.auth.exception;
+
+import com.dev_high.common.exception.CustomException;
+import org.springframework.http.HttpStatus;
+
+public class OAuthTokenIssueException extends CustomException {
+
+    public OAuthTokenIssueException() {
+        super(
+                HttpStatus.BAD_GATEWAY,
+                "소셜 로그인 토큰 응답이 올바르지 않습니다."
+        );
+    }
+}

--- a/user/src/main/java/com/dev_high/user/user/application/UserDomainService.java
+++ b/user/src/main/java/com/dev_high/user/user/application/UserDomainService.java
@@ -64,7 +64,8 @@ public class UserDomainService {
                 socialProfileResponse.nickname(),
                 socialProfileResponse.phoneNumber(),
                 socialProfileResponse.provider(),
-                socialProfileResponse.providerUserId()
+                socialProfileResponse.providerUserId(),
+                socialProfileResponse.providerToken()
 
         );
 

--- a/user/src/main/java/com/dev_high/user/user/domain/Role.java
+++ b/user/src/main/java/com/dev_high/user/user/domain/Role.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import java.util.UUID;
 
 @Entity
-@Table(name = "role", schema = "\"user\"")
+@Table(name = "role", schema = "user")
 @Getter
 public class Role {
         @Id

--- a/user/src/main/java/com/dev_high/user/user/domain/User.java
+++ b/user/src/main/java/com/dev_high/user/user/domain/User.java
@@ -8,7 +8,7 @@ import java.time.OffsetDateTime;
 import lombok.Getter;
 
 @Entity
-@Table(name = "\"user\"", schema = "\"user\"")
+@Table(name = "user", schema = "user")
 @Getter
 public class User {
 
@@ -38,11 +38,14 @@ public class User {
     private UserStatus userStatus;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 50)
+    @Column(length = 50)
     private OAuthProvider provider;
 
-    @Column(name = "provider_user_id", nullable = false, length = 100)
+    @Column(name = "provider_user_id", length = 100)
     private String providerUserId;
+
+    @Column(name = "provider_token", length = 300)
+    private String providerToken;
 
     @Column(name = "deleted_yn",  nullable = false)
     private String deletedYn;
@@ -50,13 +53,13 @@ public class User {
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
 
-    @Column(name = "created_by", length = 50)
+    @Column(name = "created_by", length = 50, nullable = false)
     private String createdBy;
 
     @Column(name = "created_at", nullable = false)
     private OffsetDateTime createdAt = OffsetDateTime.now();
 
-    @Column(name = "updated_by", length = 50)
+    @Column(name = "updated_by", length = 50, nullable = false)
     private String updatedBy;
 
     @Column(name = "updated_at", nullable = false)
@@ -89,13 +92,14 @@ public class User {
         this.phoneNumber = phoneNumber;
     }
 
-    public User(String email, String name, String nickname, String phoneNumber, OAuthProvider provider, String providerUserId) {
+    public User(String email, String name, String nickname, String phoneNumber, OAuthProvider provider, String providerUserId, String providerToken) {
         this.email = email;
         this.name = name;
         this.nickname = nickname;
         this.phoneNumber = phoneNumber;
         this.provider = provider;
         this.providerUserId = providerUserId;
+        this.providerToken = providerToken;
     }
 
     public void updateUser(UpdateUserCommand command) {
@@ -114,13 +118,15 @@ public class User {
         this.deletedYn = "Y";
     }
 
-    public void updateStatus(UserStatus status) {
-        this.userStatus = status;
-    }
-
     public void link(SocialProfileResponse profile) {
         this.provider = profile.provider();
         this.providerUserId = profile.providerUserId();
+        this.providerToken = profile.providerToken();
     }
 
+    public void unlink() {
+        this.provider = null;
+        this.providerUserId = null;
+        this.providerToken = null;
+    }
 }

--- a/user/src/main/java/com/dev_high/user/wishlist/domain/Wishlist.java
+++ b/user/src/main/java/com/dev_high/user/wishlist/domain/Wishlist.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import java.time.OffsetDateTime;
 
 @Entity
-@Table(name = "wishlist", schema = "\"user\"")
+@Table(name = "wishlist", schema = "user")
 @Getter
 public class Wishlist {
 


### PR DESCRIPTION
## 📄 배경
- 탈퇴 시 소셜 계정 연동 해제를 하지 않은 경우 재가입 시 사용자에게 가입 보다는 다시 로그인하는 느낌을 줌
- ES에 임베딩할 때 상품 정보를 너무 원문으로 저장하여 불필요한 줄바꿈과 특수 문자가 모두 저장됨

---

## 🎯 의도
- 탈퇴 시 소셜 계정 연동이 된 계정의 경우 자동으로 연동 해제를 하고 계정 연동 정보를 모두 null로 처리함
-ES에 임베딩하는 상품 정보를 임베딩 전에 전처리함(공백과 불필요한 특수 문자 제거)

---

## ✅ 작업 내용

- [x]  탈퇴 시 소셜 계정 연동 해제 및 정보 삭제
- [x]   ES 내 임베딩 형식 변경 및 상품 정보 전처리 과정 추가
---

## 🙋🏻 주요 리뷰 요청 사항
리뷰 시 중점적으로 봐주었으면 하는 부분을 작성해 주세요.
